### PR TITLE
CLI and Update

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+1.2.0 TBD
+------------------
+- add TileMatrixSet minzoom/maxzoom properties
+- fix TileMatrixSet.tile calculation
+- add TileMatrixSet.tiles function (replicat from mercantile)
+- add buffer and projected options to TileMatrixSet.feature method
+- removes mercantile as dependencies
+- add CLI 
+
 1.1.1 (2020-05-15)
 ------------------
 - Fix bad default TMS files (#13)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,12 @@
 - add TileMatrixSet.tiles function (replicat from mercantile)
 - add buffer and projected options to TileMatrixSet.feature method
 - removes mercantile as dependencies
-- add CLI 
+- add CLI
+- renamed `morecantile.TileMatrixSet.point_towgs84` to `morecantile.TileMatrixSet.lnglat` (matches mercantile)
+- renamed `morecantile.TileMatrixSet.point_fromwgs84` to `morecantile.TileMatrixSet.xy` (matches mercantile)
+- add `truncate` option in `morecantile.TileMatrixSet.tile` (matches mercantile)
+- re-order buffer and precision options in `morecantile.TileMatrixSet.feature` (matches mercantile)
+- uses mercantile's tests
 
 1.1.1 (2020-05-15)
 ------------------

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ for matrix in tms:
 ```
 
 ### Define custom grid
+
+Note: TMS CRS must be defined by a EPSG number.
+
 ```python
 import morecantile
 from rasterio.crs import CRS
@@ -202,6 +205,34 @@ my_tms_doc = "~/a_tms_doc.json"
 
 tms = morecantile.TileMatrixSet.parse_file(my_tms_doc)
 ```
+
+## Morecantile CLI
+
+The CLI is heavily inspired from mercantile's CLI.
+
+```
+morecantile --help
+Usage: morecantile [OPTIONS] COMMAND [ARGS]...
+
+  Command line interface for the Morecantile Python package.
+
+Options:
+  -v, --verbose  Increase verbosity.
+  -q, --quiet    Decrease verbosity.
+  --version      Show the version and exit.
+  --help         Show this message and exit.
+
+Commands:
+  custom          Create Custom TileMatrixSet
+  shapes          Print the shapes of tiles as GeoJSON.
+  tiles           Print tiles that overlap or contain a lng/lat point, bounding box, or GeoJSON objects.
+
+  tms             Print TileMatrixSet JSON document.
+  tms-to-geojson  Print TileMatrixSet MatrixSet as GeoJSON.
+```
+
+See [docs/cli.md](docs/cli.md) for more about the morcantile program.
+
 
 ## Contribution & Development
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,193 @@
+
+# Morecantile CLI
+
+The CLI is heavily inspired from mercantile's CLI.
+
+```
+morecantile --help
+Usage: morecantile [OPTIONS] COMMAND [ARGS]...
+
+  Command line interface for the Morecantile Python package.
+
+Options:
+  -v, --verbose  Increase verbosity.
+  -q, --quiet    Decrease verbosity.
+  --version      Show the version and exit.
+  --help         Show this message and exit.
+
+Commands:
+  tiles           Print tiles that overlap or contain a lng/lat point, bounding box, or GeoJSON objects.
+  shapes          Print the shapes of tiles as GeoJSON.
+  custom          Create Custom TileMatrixSet
+  tms             Print TileMatrixSet JSON document.
+  tms-to-geojson  Print TileMatrixSet MatrixSet as GeoJSON.
+```
+
+## Tiles
+
+With the tiles command you can write descriptions of tiles intersecting with a geographic point, bounding box, or GeoJSON object.
+
+```
+$ morecantile tiles --help
+Usage: morecantile tiles [OPTIONS] [ZOOM] [INPUT]
+
+  Lists TMS tiles at ZOOM level intersecting GeoJSON [west, south, east,
+  north] bounding boxen, features, or collections read from stdin. Output is
+  a JSON [x, y, z] array.
+
+  Input may be a compact newline-delimited sequences of JSON or a pretty-
+  printed ASCII RS-delimited sequence of JSON (like
+  https://tools.ietf.org/html/rfc8142 and
+  https://tools.ietf.org/html/rfc7159).
+
+  Example: $ echo "[-105.05, 39.95, -105, 40]" | morecantiles tiles 12
+  Output: [852, 1550, 12] [852, 1551, 12] [853, 1550, 12] [853, 1551, 12]
+
+Options:
+  --identifier TileMatrixSet identifier.
+               One of :
+                - LINZAntarticaMapTilegrid
+                - EuropeanETRS89_LAEAQuad
+                - CanadianNAD83_LCC
+                - UPSArcticWGS84Quad
+                - NZTM2000
+                - UTM31WGS84Quad
+                - UPSAntarcticWGS84Quad
+                - WorldMercatorWGS84Quad
+                - WorldCRS84Quad
+                - WebMercatorQuad             
+  --seq / --lf                    Write a RS-delimited JSON sequence (default is LF).
+  --help                          Show this message and exit.
+```
+
+## Shapes
+
+The shapes command writes TMS tile shapes to several forms of GeoJSON.
+
+```
+$ morecantile shapes --help
+Usage: morecantile shapes [OPTIONS] [INPUT]
+
+  Reads one or more Web Mercator tile descriptions from stdin and writes
+  either a GeoJSON feature collection (the default) or a JSON sequence of
+  GeoJSON features/collections to stdout.
+
+  Input may be a compact newline-delimited sequences of JSON or a pretty-
+  printed ASCII RS-delimited sequence of JSON (like
+  https://tools.ietf.org/html/rfc8142 and
+  https://tools.ietf.org/html/rfc7159).
+
+  Tile descriptions may be either an [x, y, z] array or a JSON object of the
+  form {"tile": [x, y, z], "properties": {"name": "foo", ...}}
+
+  In the latter case, the properties object will be used to update the
+  properties object of the output feature.
+
+Options:
+  --identifier TileMatrixSet identifier.
+               One of :
+                - LINZAntarticaMapTilegrid
+                - EuropeanETRS89_LAEAQuad
+                - CanadianNAD83_LCC
+                - UPSArcticWGS84Quad
+                - NZTM2000
+                - UTM31WGS84Quad
+                - UPSAntarcticWGS84Quad
+                - WorldMercatorWGS84Quad
+                - WorldCRS84Quad
+                - WebMercatorQuad  
+  --precision INTEGER             Decimal precision of coordinates.
+  --indent INTEGER                Indentation level for JSON output
+  --compact / --no-compact        Use compact separators (',', ':').
+  --projected / --geographic      Output coordinate system
+  --seq                           Write a RS-delimited JSON sequence (default is LF).
+  --feature                       Output as sequence of GeoJSON features (the default).
+  --bbox                          Output as sequence of GeoJSON bbox arrays.
+  --collect                       Output as a GeoJSON feature collections.
+  --extents / --no-extents        Write shape extents as ws-separated strings (default is False).
+  --buffer FLOAT                  Shift shape x and y values by a constant number
+  --help                          Show this message and exit.
+```
+
+## Custom
+
+With the custom command you can create custom TileMatrixSet documents.
+
+```
+$ morecantile custom --help
+Usage: morecantile custom [OPTIONS]
+
+  Create Custom TMS.
+
+Options:
+  --epsg INTEGER         EPSG number.  [required]
+  --extent FLOAT...      left, bottom, right, top Bounding box of the Tile Matrix Set.  [required]
+  --name TEXT            Identifier of the custom TMS.
+  --minzoom INTEGER      Minumum Zoom level.
+  --maxzoom INTEGER      Maximum Zoom level.
+  --tile-width INTEGER   Width of each tile.
+  --tile-height INTEGER  Height of each tile.
+  --extent-epsg INTEGER  EPSG number for the bounding box.
+  --help                 Show this message and exit.
+```
+
+## tms
+
+The tms command returns the TileMatrixSet document
+
+```
+$ morecantile tms --help   
+Usage: morecantile tms [OPTIONS]
+
+  Print TMS JSON.
+
+Options:
+  --identifier TileMatrixSet identifier.
+               One of :
+                - LINZAntarticaMapTilegrid
+                - EuropeanETRS89_LAEAQuad
+                - CanadianNAD83_LCC
+                - UPSArcticWGS84Quad
+                - NZTM2000
+                - UTM31WGS84Quad
+                - UPSAntarcticWGS84Quad
+                - WorldMercatorWGS84Quad
+                - WorldCRS84Quad
+                - WebMercatorQuad
+  --help                          Show this message and exit.
+```
+
+## tms-to-geojson
+
+Create a GeoJSON from a TMS document
+
+```
+$ morecantile tms-to-geojson --help
+Usage: morecantile tms-to-geojson [OPTIONS] [INPUT]
+
+  Print TMS document as GeoJSON.
+
+Options:
+  --level INTEGER             Zoom/Matrix level.  [required]
+  --precision INTEGER         Decimal precision of coordinates.
+  --indent INTEGER            Indentation level for JSON output
+  --compact / --no-compact    Use compact separators (',', ':').
+  --projected / --geographic  Output coordinate system
+  --seq                       Write a RS-delimited JSON sequence (default is LF).
+  --feature                   Output as sequence of GeoJSON features (the default).
+  --bbox                      Output as sequence of GeoJSON bbox arrays.
+  --collect                   Output as a GeoJSON feature collections.
+  --extents / --no-extents    Write shape extents as ws-separated strings (default is False).
+  --buffer FLOAT              Shift shape x and y values by a constant number
+  --help                      Show this message and exit.
+```
+
+## Examples
+
+```
+$ rio bounds eu.tif| morecantile tiles --zoom 1  # like mercantiles
+
+$ morecantile custom --epsg 3413 --extent -4194300 -4194300 4194300 4194300 --minzoom 0 --maxzoom 8 --tile-width 512 --tile-height 512 | morecantile tms-to-geojson --level 3 --projected --collect > l3.geojson
+
+$ rio bounds eu.tif | morecantile tiles 4 --identifier EuropeanETRS89_LAEAQuad  | morecantile shapes --identifier EuropeanETRS89_LAEAQuad --collect > z4.geojson
+```

--- a/morecantile/errors.py
+++ b/morecantile/errors.py
@@ -9,6 +9,10 @@ class InvalidIdentifier(MorecantileError):
     """Invalid TileMatrixSet indentifier."""
 
 
+class InvalidLatitudeError(MorecantileError):
+    """Raised when math errors occur beyond ~85 degrees N or S"""
+
+
 class TileArgParsingError(MorecantileError):
     """Raised when errors occur in parsing a function's tile arg(s)"""
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -2,18 +2,20 @@
 import math
 import os
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from pydantic import AnyHttpUrl, BaseModel, Field, validator
 from rasterio.crs import CRS
-from rasterio.warp import transform, transform_bounds
+from rasterio.features import bounds as feature_bounds
+from rasterio.warp import transform, transform_bounds, transform_geom
 
 from .commons import Coords, CoordsBbox, Tile
 from .errors import DeprecationWarning, InvalidIdentifier
-from .utils import _parse_tile_arg, meters_per_unit
+from .utils import _parse_tile_arg, bbox_to_feature, meters_per_unit, truncate_lnglat
 
 NumType = Union[float, int]
 BoundsType = Tuple[NumType, NumType]
+LL_EPSILON = 1e-11
 WGS84_CRS = CRS.from_epsg(4326)
 
 
@@ -74,6 +76,16 @@ class TileMatrixSet(BaseModel):
     def crs(self) -> CRS:
         """Fetch CRS from epsg"""
         return CRS.from_user_input(self.supportedCRS)
+
+    @property
+    def minzoom(self) -> int:
+        """TileMatrixSet minimum TileMatrix identifier"""
+        return int(self.tileMatrix[0].identifier)
+
+    @property
+    def maxzoom(self) -> int:
+        """TileMatrixSet maximum TileMatrix identifier"""
+        return int(self.tileMatrix[-1].identifier)
 
     @classmethod
     def load(cls, name: str):
@@ -189,6 +201,21 @@ class TileMatrixSet(BaseModel):
             return list(filter(lambda m: m.identifier == str(zoom), self.tileMatrix))[0]
         except IndexError:
             raise Exception(f"TileMatrix not found for level: {zoom}")
+
+    def bbox(self, zoom: int) -> CoordsBbox:
+        """TileMatrix bounds."""
+        matrix = self.matrix(zoom)
+
+        x_res = self._resolution(matrix)
+        y_res = -x_res
+
+        left, top = matrix.topLeftCorner
+        tile_x_size = x_res * matrix.tileWidth
+        tile_y_size = y_res * matrix.tileHeight
+
+        right = left + tile_x_size * matrix.matrixWidth
+        bottom = top + tile_y_size * matrix.matrixHeight
+        return CoordsBbox(left, bottom, right, top)
 
     def _resolution(self, matrix: TileMatrix) -> float:
         """
@@ -335,12 +362,74 @@ class TileMatrixSet(BaseModel):
         right, bottom = self.ul(tile.x + 1, tile.y + 1, tile.z)
         return CoordsBbox(left, bottom, right, top)
 
+    def tiles(
+        self,
+        west: float,
+        south: float,
+        east: float,
+        north: float,
+        zooms: Sequence[int],
+        truncate: bool = False,
+    ):
+        """
+        Get the tiles overlapped by a geographic bounding box
+
+        Parameters
+        ----------
+        west, south, east, north : sequence of float
+            Bounding values in decimal degrees.
+        zooms : int or sequence of int
+            One or more zoom levels.
+        truncate : bool, optional
+            Whether or not to truncate inputs to web mercator limits.
+
+        Yields
+        ------
+        Tile
+
+        Notes
+        -----
+        A small epsilon is used on the south and east parameters so that this
+        function yields exactly one tile when given the bounds of that same tile.
+
+        """
+        if isinstance(zooms, int):
+            zooms = (zooms,)
+
+        if truncate:
+            west, south = truncate_lnglat(west, south)
+            east, north = truncate_lnglat(east, north)
+
+        if west > east:
+            bbox_west = (-180.0, south, east, north)
+            bbox_east = (west, south, 180.0, north)
+            bboxes = [bbox_west, bbox_east]
+        else:
+            bboxes = [(west, south, east, north)]
+
+        for w, s, e, n in bboxes:
+            # TODO: should we clamp to the min/max bounds of the matrix
+            # Clamp bounding values.
+            # w = max(-180.0, w)
+            # s = max(-85.051129, s)
+            # e = min(180.0, e)
+            # n = min(85.051129, n)
+            for z in zooms:
+                ul_tile = self.tile(w, n, z)
+                lr_tile = self.tile(e - LL_EPSILON, s + LL_EPSILON, z)
+
+                for i in range(ul_tile.x, lr_tile.x + 1):
+                    for j in range(ul_tile.y, lr_tile.y + 1):
+                        yield Tile(i, j, z)
+
     def feature(
         self,
         tile: Tile,
         fid: Optional[str] = None,
-        props: Optional[Dict] = None,
+        props: Dict = {},
+        buffer: Optional[NumType] = None,
         precision: Optional[int] = None,
+        projected: bool = False,
     ) -> Dict:
         """
         Get the GeoJSON feature corresponding to a tile.
@@ -355,39 +444,37 @@ class TileMatrixSet(BaseModel):
             A feature id.
         props : dict, optional
             Optional extra feature properties.
-        precision : int, optional
-            GeoJSON coordinates will be truncated to this number of decimal
-            places.
+        buffer : float, optional
+            Optional buffer distance for the GeoJSON polygon.
+        precision: float
+            If >= 0, geometry coordinates will be rounded to this number of decimal,
+            otherwise original coordinate values will be preserved (default).
+        projected : bool, optional
+            Return coordinates in TMS projection. Default is false.
 
         Returns
         -------
         dict
 
         """
-        west, south, east, north = self.bounds(tile)
+        west, south, east, north = self.xy_bounds(tile)
 
-        if precision and precision >= 0:
-            west, south, east, north = (
-                round(v, precision) for v in (west, south, east, north)
-            )
+        if buffer:
+            west -= buffer
+            south -= buffer
+            east += buffer
+            north += buffer
 
-        bbox = [min(west, east), min(south, north), max(west, east), max(south, north)]
-        geom = {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [west, south],
-                    [west, north],
-                    [east, north],
-                    [east, south],
-                    [west, south],
-                ]
-            ],
-        }
+        geom = bbox_to_feature(west, south, east, north)
+
+        precision = precision or -1
+        if not projected:
+            geom = transform_geom(self.crs, WGS84_CRS, geom, precision=precision)
+
         xyz = str(tile)
         feat: Dict[str, Any] = {
             "type": "Feature",
-            "bbox": bbox,
+            "bbox": feature_bounds(geom),
             "id": xyz,
             "geometry": geom,
             "properties": {
@@ -396,6 +483,17 @@ class TileMatrixSet(BaseModel):
                 "grid_crs": self.crs.to_string(),
             },
         }
+
+        if projected:
+            warnings.warn(
+                "CRS is no longer part of the GeoJSON specification."
+                "Other projection than EPSG:4326 might not be supported.",
+                UserWarning,
+            )
+            feat.update(
+                {"crs": {"type": "EPSG", "properties": {"code": self.crs.to_epsg()}}}
+            )
+
         if props:
             feat["properties"].update(props)
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -255,19 +255,12 @@ class TileMatrixSet(BaseModel):
 
         """
         matrix = self.matrix(zoom)
-
         res = self._resolution(matrix)
-        xtile = int(
-            math.floor(
-                (xcoord - matrix.topLeftCorner[0])
-                / float(res * matrix.tileWidth * (matrix.matrixWidth / (2 ** zoom)))
-            )
+        xtile = math.floor(
+            (xcoord - matrix.topLeftCorner[0]) / float(res * matrix.tileWidth)
         )
-        ytile = int(
-            math.floor(
-                (matrix.topLeftCorner[1] - ycoord)
-                / float(res * matrix.tileHeight * (matrix.matrixHeight / (2 ** zoom)))
-            )
+        ytile = math.floor(
+            (matrix.topLeftCorner[1] - ycoord) / float(res * matrix.tileHeight)
         )
         return Tile(x=xtile, y=ytile, z=zoom)
 

--- a/morecantile/scripts/__init__.py
+++ b/morecantile/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""morecantile CLI."""

--- a/morecantile/scripts/cli.py
+++ b/morecantile/scripts/cli.py
@@ -1,0 +1,494 @@
+"""Morecantile command line interface"""
+
+import json
+import logging
+
+import click
+from mercantile.scripts import configure_logging, coords, iter_lines, normalize_input
+from rasterio.crs import CRS
+
+import morecantile
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_source(input):
+    """Yield features from GeoJSON source."""
+    src = iter(normalize_input(input))
+    first_line = next(src)
+
+    # If input is RS-delimited JSON sequence.
+    if first_line.startswith(u"\x1e"):
+
+        def feature_gen():
+            buffer = first_line.strip(u"\x1e")
+            for line in src:
+                if line.startswith(u"\x1e"):
+                    if buffer:
+                        yield json.loads(buffer)
+                    buffer = line.strip(u"\x1e")
+                else:
+                    buffer += line
+            else:
+                yield json.loads(buffer)
+
+    else:
+
+        def feature_gen():
+            yield json.loads(first_line)
+            for line in src:
+                yield json.loads(line)
+
+    return feature_gen()
+
+
+# The CLI command group.
+@click.group(help="Command line interface for the Morecantile Python package.")
+@click.option("--verbose", "-v", count=True, help="Increase verbosity.")
+@click.option("--quiet", "-q", count=True, help="Decrease verbosity.")
+@click.version_option(version=morecantile.version, message="%(version)s")
+@click.pass_context
+def cli(ctx, verbose, quiet):
+    """Execute the main mercantile command"""
+    verbosity = verbose - quiet
+    configure_logging(verbosity)
+    ctx.obj = {}
+    ctx.obj["verbosity"] = verbosity
+
+
+# Commands are below.
+
+
+# The shapes command.
+@cli.command(short_help="Print the shapes of tiles as GeoJSON.")
+# This input is either a filename, stdin, or a string.
+@click.argument("input", default="-", required=False)
+@click.option(
+    "--identifier",
+    type=click.Choice(morecantile.tms.list()),
+    default="WebMercatorQuad",
+    help="TileMatrixSet identifier.",
+)
+# Coordinate precision option.
+@click.option(
+    "--precision", type=int, default=None, help="Decimal precision of coordinates."
+)
+# JSON formatting options.
+@click.option(
+    "--indent", default=None, type=int, help="Indentation level for JSON output"
+)
+@click.option(
+    "--compact/--no-compact", default=False, help="Use compact separators (',', ':')."
+)
+@click.option(
+    "--projected/--geographic",
+    "projected",
+    default=False,
+    help="Output coordinate system",
+)
+@click.option(
+    "--seq",
+    is_flag=True,
+    default=False,
+    help="Write a RS-delimited JSON sequence (default is LF).",
+)
+# GeoJSON feature (default) or collection switch. Meaningful only
+# when --x-json-seq is used.
+@click.option(
+    "--feature",
+    "output_mode",
+    flag_value="feature",
+    default=True,
+    help="Output as sequence of GeoJSON features (the default).",
+)
+@click.option(
+    "--bbox",
+    "output_mode",
+    flag_value="bbox",
+    help="Output as sequence of GeoJSON bbox arrays.",
+)
+@click.option(
+    "--collect",
+    is_flag=True,
+    default=False,
+    help="Output as a GeoJSON feature collections.",
+)
+# Optionally write out bboxen in a form that goes
+# straight into GDAL utilities like gdalwarp.
+@click.option(
+    "--extents/--no-extents",
+    default=False,
+    help="Write shape extents as ws-separated strings (default is " "False).",
+)
+# Optionally buffer the shapes by shifting the x and y values of each
+# vertex by a constant number of decimal degrees or meters (depending
+# on whether --geographic or --mercator is in effect).
+@click.option(
+    "--buffer",
+    type=float,
+    default=None,
+    help="Shift shape x and y values by a constant number",
+)
+@click.pass_context
+def shapes(
+    ctx,
+    input,
+    identifier,
+    precision,
+    indent,
+    compact,
+    projected,
+    seq,
+    output_mode,
+    collect,
+    extents,
+    buffer,
+):
+    """
+    Reads one or more Web Mercator tile descriptions
+    from stdin and writes either a GeoJSON feature collection (the
+    default) or a JSON sequence of GeoJSON features/collections to
+    stdout.
+
+    Input may be a compact newline-delimited sequences of JSON or
+    a pretty-printed ASCII RS-delimited sequence of JSON (like
+    https://tools.ietf.org/html/rfc8142 and
+    https://tools.ietf.org/html/rfc7159).
+
+    Tile descriptions may be either an [x, y, z] array or a JSON
+    object of the form {"tile": [x, y, z], "properties": {"name": "foo", ...}}
+
+    In the latter case, the properties object will be used to update
+    the properties object of the output feature.
+
+    """
+    tms = morecantile.tms.get(identifier)
+
+    dump_kwds = {"sort_keys": True}
+    if indent:
+        dump_kwds["indent"] = indent
+    if compact:
+        dump_kwds["separators"] = (",", ":")
+
+    src = normalize_input(input)
+    features = []
+    col_xs = []
+    col_ys = []
+
+    for i, line in enumerate(iter_lines(src)):
+        obj = json.loads(line)
+        if isinstance(obj, dict):
+            x, y, z = obj["tile"][:3]
+            props = obj.get("properties")
+            fid = obj.get("id")
+        elif isinstance(obj, list):
+            x, y, z = obj[:3]
+            props = {}
+            fid = None
+        else:
+            raise click.BadParameter("{0}".format(obj), param=input, param_hint="input")
+
+        feature = tms.feature(
+            (x, y, z),
+            fid=fid,
+            props=props,
+            projected=projected,
+            buffer=buffer,
+            precision=precision,
+        )
+        bbox = feature["bbox"]
+        w, s, e, n = bbox
+        col_xs.extend([w, e])
+        col_ys.extend([s, n])
+
+        if collect:
+            features.append(feature)
+        elif extents:
+            click.echo(" ".join(map(str, bbox)))
+        else:
+            if seq:
+                click.echo(u"\x1e")
+            if output_mode == "bbox":
+                click.echo(json.dumps(bbox, **dump_kwds))
+            elif output_mode == "feature":
+                click.echo(json.dumps(feature, **dump_kwds))
+
+    if collect and features:
+        bbox = [min(col_xs), min(col_ys), max(col_xs), max(col_ys)]
+        click.echo(
+            json.dumps(
+                {"type": "FeatureCollection", "bbox": bbox, "features": features},
+                **dump_kwds
+            )
+        )
+
+
+# The tiles command.
+@cli.command(
+    short_help=(
+        "Print tiles that overlap or contain a lng/lat point, "
+        "bounding box, or GeoJSON objects."
+    )
+)
+# Mandatory Mercator zoom level argument.
+@click.argument("zoom", type=int, default=-1)
+# This input is either a filename, stdin, or a string.
+# Has to follow the zoom arg.
+@click.argument("input", default="-", required=False)
+@click.option(
+    "--identifier",
+    type=click.Choice(morecantile.tms.list()),
+    default="WebMercatorQuad",
+    help="TileMatrixSet identifier.",
+)
+@click.option(
+    "--seq/--lf",
+    default=False,
+    help="Write a RS-delimited JSON sequence (default is LF).",
+)
+@click.pass_context
+def tiles(ctx, zoom, input, identifier, seq):
+    """
+    Lists TMS tiles at ZOOM level intersecting
+    GeoJSON [west, south, east, north] bounding boxen, features, or
+    collections read from stdin. Output is a JSON
+    [x, y, z] array.
+
+    Input may be a compact newline-delimited sequences of JSON or
+    a pretty-printed ASCII RS-delimited sequence of JSON (like
+    https://tools.ietf.org/html/rfc8142 and
+    https://tools.ietf.org/html/rfc7159).
+
+    Example:
+    $ echo "[-105.05, 39.95, -105, 40]" | morecantiles tiles 12
+    Output:
+    [852, 1550, 12]
+    [852, 1551, 12]
+    [853, 1550, 12]
+    [853, 1551, 12]
+
+    """
+    tms = morecantile.tms.get(identifier)
+
+    for obj in normalize_source(input):
+        if isinstance(obj, list):
+            bbox = obj
+            if len(bbox) == 2:
+                bbox += bbox
+
+            if len(bbox) != 4:
+                raise click.BadParameter(
+                    "{0}".format(bbox), param=input, param_hint="input"
+                )
+
+        elif isinstance(obj, dict):
+            if "bbox" in obj:
+                bbox = obj["bbox"]
+            else:
+                box_xs = []
+                box_ys = []
+                for feat in obj.get("features", [obj]):
+                    lngs, lats = zip(*list(coords(feat)))
+                    box_xs.extend([min(lngs), max(lngs)])
+                    box_ys.extend([min(lats), max(lats)])
+
+                bbox = min(box_xs), min(box_ys), max(box_xs), max(box_ys)
+
+        west, south, east, north = bbox
+        epsilon = 1.0e-10
+
+        if east != west and north != south:
+            # 2D bbox
+            # shrink the bounds a small amount so that
+            # shapes/tiles round trip.
+            west += epsilon
+            south += epsilon
+            east -= epsilon
+            north -= epsilon
+
+        for tile in tms.tiles(west, south, east, north, [zoom], truncate=False):
+            vals = (tile.x, tile.y, zoom)
+            output = json.dumps(vals)
+            if seq:
+                click.echo(u"\x1e")
+
+            click.echo(output)
+
+
+# The tms command.
+@cli.command(short_help="Print TileMatrixSet JSON document.")
+@click.option(
+    "--identifier",
+    type=click.Choice(morecantile.tms.list()),
+    help="TileMatrixSet identifier.",
+    required=True,
+)
+def tms(identifier):
+    """Print TMS JSON."""
+    tms = morecantile.tms.get(identifier)
+    click.echo(json.dumps(tms.dict(exclude_none=True)))
+
+
+# The custom command.
+@cli.command(short_help="Create Custom TileMatrixSet")
+@click.option(
+    "--epsg", type=int, help="EPSG number.", required=True,
+)
+@click.option(
+    "--extent",
+    type=float,
+    nargs=4,
+    help="left, bottom, right, top Bounding box of the Tile Matrix Set.",
+    required=True,
+)
+@click.option(
+    "--name",
+    type=str,
+    help="Identifier of the custom TMS.",
+    default="CustomTileMatrixSet",
+)
+@click.option("--minzoom", type=int, default=0, help="Minumum Zoom level.")
+@click.option("--maxzoom", type=int, default=24, help="Maximum Zoom level.")
+@click.option("--tile-width", type=int, default=256, help="Width of each tile.")
+@click.option("--tile-height", type=int, default=256, help="Height of each tile.")
+@click.option(
+    "--extent-epsg", type=int, help="EPSG number for the bounding box.",
+)
+def custom(epsg, extent, name, minzoom, maxzoom, tile_width, tile_height, extent_epsg):
+    """Create Custom TMS."""
+    extent_crs = CRS.from_epsg(extent_epsg) if extent_epsg else None
+
+    tms = morecantile.TileMatrixSet.custom(
+        extent,
+        CRS.from_epsg(epsg),
+        identifier=name,
+        minzoom=minzoom,
+        maxzoom=maxzoom,
+        tile_width=tile_width,
+        tile_height=tile_height,
+        extent_crs=extent_crs,
+    )
+    click.echo(json.dumps(tms.dict(exclude_none=True)))
+
+
+# The tms_to_geojson command.
+@cli.command(short_help="Print TileMatrixSet MatrixSet as GeoJSON.")
+@click.argument("input", type=click.File(mode="r"), default="-", required=False)
+@click.option("--level", type=int, required=True, help="Zoom/Matrix level.")
+# Coordinate precision option.
+@click.option(
+    "--precision", type=int, default=None, help="Decimal precision of coordinates."
+)
+# JSON formatting options.
+@click.option(
+    "--indent", default=None, type=int, help="Indentation level for JSON output"
+)
+@click.option(
+    "--compact/--no-compact", default=False, help="Use compact separators (',', ':')."
+)
+@click.option(
+    "--projected/--geographic",
+    "projected",
+    default=False,
+    help="Output coordinate system",
+)
+@click.option(
+    "--seq",
+    is_flag=True,
+    default=False,
+    help="Write a RS-delimited JSON sequence (default is LF).",
+)
+# GeoJSON feature (default) or collection switch. Meaningful only
+# when --x-json-seq is used.
+@click.option(
+    "--feature",
+    "output_mode",
+    flag_value="feature",
+    default=True,
+    help="Output as sequence of GeoJSON features (the default).",
+)
+@click.option(
+    "--bbox",
+    "output_mode",
+    flag_value="bbox",
+    help="Output as sequence of GeoJSON bbox arrays.",
+)
+@click.option(
+    "--collect",
+    is_flag=True,
+    default=False,
+    help="Output as a GeoJSON feature collections.",
+)
+# Optionally write out bboxen in a form that goes
+# straight into GDAL utilities like gdalwarp.
+@click.option(
+    "--extents/--no-extents",
+    default=False,
+    help="Write shape extents as ws-separated strings (default is " "False).",
+)
+# Optionally buffer the shapes by shifting the x and y values of each
+# vertex by a constant number of decimal degrees or meters (depending
+# on whether --geographic or --mercator is in effect).
+@click.option(
+    "--buffer",
+    type=float,
+    default=None,
+    help="Shift shape x and y values by a constant number",
+)
+def tms_to_geojson(
+    input,
+    level,
+    precision,
+    indent,
+    compact,
+    projected,
+    seq,
+    output_mode,
+    collect,
+    extents,
+    buffer,
+):
+    """Print TMS document as GeoJSON."""
+    tms = morecantile.TileMatrixSet(**json.load(input))
+    matrix = tms.matrix(level)
+
+    dump_kwds = {"sort_keys": True}
+    if indent:
+        dump_kwds["indent"] = indent
+    if compact:
+        dump_kwds["separators"] = (",", ":")
+
+    features = []
+    col_xs = []
+    col_ys = []
+
+    for x in range(0, matrix.matrixWidth):
+        for y in range(0, matrix.matrixHeight):
+            feature = tms.feature(
+                (x, y, level), projected=projected, buffer=buffer, precision=precision,
+            )
+            bbox = feature["bbox"]
+            w, s, e, n = bbox
+            col_xs.extend([w, e])
+            col_ys.extend([s, n])
+
+            if collect:
+                features.append(feature)
+            elif extents:
+                click.echo(" ".join(map(str, bbox)))
+            else:
+                if seq:
+                    click.echo(u"\x1e")
+                if output_mode == "bbox":
+                    click.echo(json.dumps(bbox, **dump_kwds))
+                elif output_mode == "feature":
+                    click.echo(json.dumps(feature, **dump_kwds))
+
+    if collect and features:
+        bbox = [min(col_xs), min(col_ys), max(col_xs), max(col_ys)]
+        feature_collection = {
+            "type": "FeatureCollection",
+            "bbox": bbox,
+            "features": features,
+        }
+        click.echo(json.dumps(feature_collection, **dump_kwds))

--- a/morecantile/scripts/cli.py
+++ b/morecantile/scripts/cli.py
@@ -49,16 +49,14 @@ def normalize_source(input):
 @click.version_option(version=morecantile.version, message="%(version)s")
 @click.pass_context
 def cli(ctx, verbose, quiet):
-    """Execute the main mercantile command"""
+    """Execute the main morecantile command"""
     verbosity = verbose - quiet
     configure_logging(verbosity)
     ctx.obj = {}
     ctx.obj["verbosity"] = verbosity
 
 
-# Commands are below.
-
-
+################################################################################
 # The shapes command.
 @cli.command(short_help="Print the shapes of tiles as GeoJSON.")
 # This input is either a filename, stdin, or a string.
@@ -223,6 +221,7 @@ def shapes(
         )
 
 
+################################################################################
 # The tiles command.
 @cli.command(
     short_help=(
@@ -315,6 +314,7 @@ def tiles(ctx, zoom, input, identifier, seq):
             click.echo(output)
 
 
+################################################################################
 # The tms command.
 @cli.command(short_help="Print TileMatrixSet JSON document.")
 @click.option(
@@ -329,6 +329,7 @@ def tms(identifier):
     click.echo(json.dumps(tms.dict(exclude_none=True)))
 
 
+################################################################################
 # The custom command.
 @cli.command(short_help="Create Custom TileMatrixSet")
 @click.option(
@@ -371,6 +372,7 @@ def custom(epsg, extent, name, minzoom, maxzoom, tile_width, tile_height, extent
     click.echo(json.dumps(tms.dict(exclude_none=True)))
 
 
+################################################################################
 # The tms_to_geojson command.
 @cli.command(short_help="Print TileMatrixSet MatrixSet as GeoJSON.")
 @click.argument("input", type=click.File(mode="r"), default="-", required=False)

--- a/morecantile/utils.py
+++ b/morecantile/utils.py
@@ -1,6 +1,7 @@
 """morecantile utils."""
 
 import math
+from typing import Dict, Tuple
 
 from rasterio.crs import CRS
 
@@ -10,7 +11,9 @@ from .errors import TileArgParsingError
 
 def _parse_tile_arg(*args) -> Tile:
     """
-    parse the *tile arg of module functions
+    Parse the *tile arg of module functions
+
+    Copy from https://github.com/mapbox/mercantile/blob/master/mercantile/__init__.py
 
     Parameters
     ----------
@@ -38,7 +41,7 @@ def _parse_tile_arg(*args) -> Tile:
 
 def meters_per_unit(crs: CRS) -> float:
     """
-    coefficient to convert the coordinate reference system (CRS)
+    Coefficient to convert the coordinate reference system (CRS)
     units into meters (metersPerUnit).
 
     From note g in http://docs.opengeospatial.org/is/17-083r2/17-083r2.html#table_2:
@@ -49,3 +52,33 @@ def meters_per_unit(crs: CRS) -> float:
     """
     # crs.linear_units_factor[1]  GDAL 3.0
     return 1.0 if crs.linear_units == "metre" else 2 * math.pi * 6378137 / 360.0
+
+
+def truncate_lnglat(lng: float, lat: float) -> Tuple[float, float]:
+    """
+    Truncate Lat Lon Geographic coordinates.
+
+    Copy from https://github.com/mapbox/mercantile/blob/master/mercantile/__init__.py
+
+    """
+    if lng > 180.0:
+        lng = 180.0
+    elif lng < -180.0:
+        lng = -180.0
+
+    if lat > 90.0:
+        lat = 90.0
+    elif lat < -90.0:
+        lat = -90.0
+
+    return lng, lat
+
+
+def bbox_to_feature(west: float, south: float, east: float, north: float) -> Dict:
+    """Create a GeoJSON feature from a bbox."""
+    return {
+        "type": "Polygon",
+        "coordinates": [
+            [[west, south], [west, north], [east, north], [east, south], [west, south]]
+        ],
+    }

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as f:
 inst_reqs = ["rasterio>=1.1", "pydantic"]
 
 extra_reqs = {
-    "test": ["pytest", "pytest-cov"],
+    "test": ["mercantile", "pytest", "pytest-cov"],
     "dev": ["pytest", "pytest-cov", "pre-commit"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 with open("README.md") as f:
     long_description = f.read()
 
-inst_reqs = ["rasterio>=1.1", "mercantile", "pydantic"]
+inst_reqs = ["rasterio>=1.1", "pydantic"]
 
 extra_reqs = {
     "test": ["pytest", "pytest-cov"],
@@ -38,4 +38,8 @@ setup(
     zip_safe=False,
     install_requires=inst_reqs,
     extras_require=extra_reqs,
+    entry_points="""
+      [console_scripts]
+      morecantile=morecantile.scripts.cli:cli
+      """,
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,200 @@
+"""Tests of the morecantile CLI"""
+
+from click.testing import CliRunner
+
+from morecantile.scripts.cli import cli
+
+
+def test_cli_shapes():
+    """
+    Test shapes.
+
+    From https://github.com/mapbox/mercantile/blob/master/tests/test_cli.py
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shapes", "--precision", "6"], "[106, 193, 9]")
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == '{"bbox": [-105.46875, 39.909736, -104.765625, 40.446947], "geometry": {"coordinates": [[[-105.46875, 39.909736], [-105.46875, 40.446947], [-104.765625, 40.446947], [-104.765625, 39.909736], [-105.46875, 39.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "EPSG:3857", "grid_name": "WebMercatorQuad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
+    )
+
+    # tile as arg
+    result = runner.invoke(cli, ["shapes", "[106, 193, 9]", "--precision", "6"])
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == '{"bbox": [-105.46875, 39.909736, -104.765625, 40.446947], "geometry": {"coordinates": [[[-105.46875, 39.909736], [-105.46875, 40.446947], [-104.765625, 40.446947], [-104.765625, 39.909736], [-105.46875, 39.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "EPSG:3857", "grid_name": "WebMercatorQuad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
+    )
+
+    # buffer
+    result = runner.invoke(
+        cli, ["shapes", "[106, 193, 9]", "--buffer", "1.0", "--precision", "6"]
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == '{"bbox": [-106.46875, 38.909736, -103.765625, 41.446947], "geometry": {"coordinates": [[[-106.46875, 38.909736], [-106.46875, 41.446947], [-103.765625, 41.446947], [-103.765625, 38.909736], [-106.46875, 38.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "EPSG:3857", "grid_name": "WebMercatorQuad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
+    )
+
+    # Output is compact
+    result = runner.invoke(cli, ["shapes", "--compact"], "[106, 193, 9]")
+    assert result.exit_code == 0
+    assert '"type":"Feature"' in result.output.strip()
+
+    # Output is indented
+    result = runner.invoke(cli, ["shapes", "--indent", "8"], "[106, 193, 9]")
+    assert result.exit_code == 0
+    assert '        "type": "Feature"' in result.output.strip()
+
+    # Shapes are collected into a feature collection
+    result = runner.invoke(cli, ["shapes", "--collect", "--feature"], "[106, 193, 9]")
+    assert result.exit_code == 0
+    assert "FeatureCollection" in result.output
+
+    # geojson is in WebMercator Projection
+    result = runner.invoke(
+        cli, ["shapes", "[106, 193, 9]", "--extents", "--projected", "--precision", "3"]
+    )
+    assert result.exit_code == 0
+    assert result.output == "-11740727.545 4852834.052 -11662456.028 4931105.569\n"
+
+    # JSON text sequences of bboxes are output.
+    result = runner.invoke(
+        cli,
+        [
+            "shapes",
+            "[106, 193, 9]",
+            "--seq",
+            "--bbox",
+            "--projected",
+            "--precision",
+            "3",
+        ],
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == "\x1e\n[-11740727.545, 4852834.052, -11662456.028, 4931105.569]\n"
+    )
+
+    # shapes_props_fid
+    result = runner.invoke(
+        cli,
+        [
+            "shapes",
+            '{"tile": [106, 193, 9], "properties": {"title": "foo"}, "id": "42"}',
+        ],
+    )
+    assert result.exit_code == 0
+    assert '"title": "foo"' in result.output
+    assert '"id": "42"' in result.output
+
+
+def test_cli_shapesWGS84():
+    """Test shapes with other projection."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["shapes", "--precision", "6", "--identifier", "WorldCRS84Quad"],
+        "[106, 193, 9]",
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == '{"bbox": [-142.734375, 21.796875, -142.382813, 22.148438], "geometry": {"coordinates": [[[-142.734375, 21.796875], [-142.734375, 22.148438], [-142.382813, 22.148438], [-142.382813, 21.796875], [-142.734375, 21.796875]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "EPSG:4326", "grid_name": "WorldCRS84Quad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
+    )
+
+
+def test_cli_tiles_ok():
+    """Test tile with correct bounds."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tiles", "14"], "[-105, 39.99, -104.99, 40]")
+    assert result.exit_code == 0
+    assert result.output == "[3413, 6202, 14]\n[3413, 6203, 14]\n"
+
+
+def test_cli_tiles_bad_bounds():
+    """Bounds of len 3 are bad."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tiles", "14"], "[-105, 39.99, -104.99]")
+    assert result.exit_code == 2
+
+
+def test_cli_tiles_multi_bounds():
+    """A LF-delimited sequence can be used as input."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["tiles", "14"], "[-105, 39.99, -104.99, 40]\n[-105, 39.99, -104.99, 40]"
+    )
+    assert result.exit_code == 0
+    assert len(result.output.strip().split("\n")) == 4
+
+
+def test_cli_tiles_multi_bounds_seq():
+    """A JSON text sequence can be used as input."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tiles", "14"],
+        "\x1e\n[-105, 39.99, -104.99, 40]\n\x1e\n[-105, 39.99, -104.99, 40]",
+    )
+    assert result.exit_code == 0
+    assert len(result.output.strip().split("\n")) == 4
+
+
+def test_cli_tiles_implicit_stdin():
+    """stdin."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tiles", "14"], "[-105, 39.99, -104.99, 40]")
+    assert result.exit_code == 0
+    assert result.output == "[3413, 6202, 14]\n[3413, 6203, 14]\n"
+
+
+def test_cli_tiles_arg():
+    """tiles arg."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tiles", "14", "[-105, 39.99, -104.99, 40]"])
+    assert result.exit_code == 0
+    assert result.output == "[3413, 6202, 14]\n[3413, 6203, 14]\n"
+
+
+def test_cli_tiles_geosjon():
+    """Geojson input."""
+    collection = '{"features": [{"geometry": {"coordinates": [[[-105.46875, 39.909736], [-105.46875, 40.446947], [-104.765625, 40.446947], [-104.765625, 39.909736], [-105.46875, 39.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}], "type": "FeatureCollection"}'
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tiles", "9"], collection)
+    assert result.exit_code == 0
+    assert result.output == "[106, 193, 9]\n[106, 194, 9]\n"
+
+
+def test_cli_strict_overlap_contain():
+    """Input from shapes."""
+    runner = CliRunner()
+    result1 = runner.invoke(cli, ["shapes"], "[2331,1185,12]")
+    assert result1.exit_code == 0
+    result2 = runner.invoke(cli, ["tiles", "12"], result1.output)
+    assert result2.exit_code == 0
+    assert result2.output == "[2331, 1185, 12]\n"
+
+
+def test_cli_tiles_seq():
+    """return a sequence of tiles."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tiles", "14", "--seq"], "[14.0859, 5.798]")
+    assert result.exit_code == 0
+    assert result.output == "\x1e\n[8833, 7927, 14]\n"
+
+
+def test_cli_tiles_points():
+    """Create tile from a point."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tiles", "14"], "[14.0859, 5.798]")
+    assert result.exit_code == 0
+    assert result.output == "[8833, 7927, 14]\n"
+
+    result = runner.invoke(
+        cli, ["tiles", "14"], '{"type":"geometry","coordinates":[14.0859, 5.798]}'
+    )
+    assert result.exit_code == 0
+    assert result.output == "[8833, 7927, 14]\n"

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -51,7 +51,7 @@ def test_tile_coordinates():
     assert tms.tile(20.0, 15.0, 5) == mercantile.tile(20.0, 15.0, 5)
 
     tms = morecantile.tms.get("WorldCRS84Quad")
-    assert tms.tile(10.0, 10.0, 5) == morecantile.Tile(16, 14, 5)
+    assert tms.tile(-39.8, 74.2, 4) == morecantile.Tile(12, 1, 4)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -5,7 +5,7 @@ import pytest
 from rasterio.crs import CRS
 
 import morecantile
-from morecantile.errors import InvalidIdentifier
+from morecantile.errors import DeprecationWarning, InvalidIdentifier
 from morecantile.utils import meters_per_unit
 
 
@@ -35,6 +35,8 @@ def test_TMSproperties():
     tms = morecantile.tms.get("WebMercatorQuad")
     assert tms.crs == CRS.from_epsg(3857)
     assert meters_per_unit(tms.crs) == 1.0
+    assert tms.minzoom == 0
+    assert tms.maxzoom == 24
 
     tms = morecantile.tms.get("WorldCRS84Quad")
     assert tms.crs == CRS.from_epsg(4326)
@@ -137,9 +139,248 @@ def test_feature():
     assert len(feat["properties"].keys()) == 3
 
     feat = tms.feature(
-        morecantile.Tile(1, 0, 1), precision=4, fid="1", props={"some": "thing"}
+        morecantile.Tile(1, 0, 1),
+        buffer=-10,
+        precision=4,
+        fid="1",
+        props={"some": "thing"},
     )
     assert feat["bbox"]
     assert feat["id"] == "1"
     assert feat["geometry"]
     assert len(feat["properties"].keys()) == 4
+
+    with pytest.warns(UserWarning):
+        feat = tms.feature(
+            morecantile.Tile(1, 0, 1), projected=True, fid="1", props={"some": "thing"}
+        )
+    assert feat["bbox"]
+    assert feat["id"] == "1"
+    assert feat["geometry"]
+    assert len(feat["properties"].keys()) == 4
+
+
+def test_point_fromwgs84():
+    """x, y for the 486-332-10 tile is correctly calculated."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    ul = tms.ul(486, 332, 10)
+    with pytest.warns(DeprecationWarning):
+        xy = tms.point_fromwgs84(*ul)
+    expected = (-1017529.7205322663, 7044436.526761846)
+    for a, b in zip(expected, xy):
+        assert round(a - b, 7) == 0
+
+
+def test_point_towgs84():
+    """test point_towgs84."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    xy = (-8366731.739810849, -1655181.9927159143)
+    with pytest.warns(DeprecationWarning):
+        lnglat = tms.point_towgs84(*xy)
+    assert round(lnglat.x, 5) == -75.15963
+    assert round(lnglat.y, 5) == -14.70462
+
+    xy = (-28366731.739810849, -1655181.9927159143)
+    with pytest.warns(DeprecationWarning):
+        lnglat = tms.point_towgs84(*xy, truncate=True)
+    # GDAL returns ('inf', 'inf') and then inf is translated to 180,90 by truncate_lnglat
+    # assert round(lnglat.x, 5) == -180.0  # in Mercantile
+    # assert round(lnglat.y, 5) == -14.70462  # in Mercantile
+    assert round(lnglat.x, 5) == 180.0
+    assert round(lnglat.y, 5) == 90
+
+
+################################################################################
+# replicate mercantile tests
+# https://github.com/mapbox/mercantile/blob/master/tests/test_funcs.py
+@pytest.mark.parametrize(
+    "args", [(486, 332, 10), [(486, 332, 10)], [morecantile.Tile(486, 332, 10)]]
+)
+def test_ul(args):
+    """test args."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    expected = (-9.140625, 53.33087298301705)
+    lnglat = tms.ul(*args)
+    for a, b in zip(expected, lnglat):
+        assert round(a - b, 7) == 0
+    assert lnglat[0] == lnglat.x
+    assert lnglat[1] == lnglat.y
+
+
+@pytest.mark.parametrize(
+    "args", [(486, 332, 10), [(486, 332, 10)], [mercantile.Tile(486, 332, 10)]]
+)
+def test_bbox(args):
+    """test bbox."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    expected = (-9.140625, 53.12040528310657, -8.7890625, 53.33087298301705)
+    bbox = tms.bounds(*args)
+    for a, b in zip(expected, bbox):
+        assert round(a - b, 7) == 0
+    assert bbox.xmin == bbox[0]
+    assert bbox.ymin == bbox[1]
+    assert bbox.xmax == bbox[2]
+    assert bbox.ymax == bbox[3]
+
+
+def test_xy_tile():
+    """x, y for the 486-332-10 tile is correctly calculated."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    ul = tms.ul(486, 332, 10)
+    xy = tms.xy(*ul)
+    expected = (-1017529.7205322663, 7044436.526761846)
+    for a, b in zip(expected, xy):
+        assert round(a - b, 7) == 0
+
+
+def test_xy_null_island():
+    """x, y for (0, 0) is correctly calculated"""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    xy = tms.xy(0.0, 0.0)
+    expected = (0.0, 0.0)
+    for a, b in zip(expected, xy):
+        assert round(a - b, 7) == 0
+
+
+def test_xy_south_pole():
+    """Return -inf for y at South Pole"""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    xy = tms.xy(0.0, -90)
+    assert xy.x == 0.0
+    assert xy.y == float("-inf")
+
+
+def test_xy_north_pole():
+    """Return inf for y at North Pole"""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    xy = tms.xy(0.0, 90)
+    assert xy.x == 0.0
+    assert xy.y == float("inf")
+
+
+def test_xy_truncate():
+    """Input is truncated"""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    assert tms.xy(-181.0, 0.0, truncate=True) == tms.xy(-180.0, 0.0)
+
+
+def test_lnglat():
+    """test lnglat."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    xy = (-8366731.739810849, -1655181.9927159143)
+    lnglat = tms.lnglat(*xy)
+    assert round(lnglat.x, 5) == -75.15963
+    assert round(lnglat.y, 5) == -14.70462
+
+    xy = (-28366731.739810849, -1655181.9927159143)
+    lnglat = tms.lnglat(*xy, truncate=True)
+    # GDAL returns ('inf', 'inf') and then inf is translated to 180,90 by truncate_lnglat
+    # assert round(lnglat.x, 5) == -180.0  # in Mercantile
+    # assert round(lnglat.y, 5) == -14.70462  # in Mercantile
+    assert round(lnglat.x, 5) == 180.0
+    assert round(lnglat.y, 5) == 90
+
+
+def test_lnglat_xy_roundtrip():
+    """Test roundtrip."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    lnglat = (-105.0844, 40.5853)
+    roundtrip = tms.lnglat(*tms.xy(*lnglat))
+    for a, b in zip(roundtrip, lnglat):
+        assert round(a - b, 7) == 0
+
+
+@pytest.mark.parametrize(
+    "args", [(486, 332, 10), [(486, 332, 10)], [mercantile.Tile(486, 332, 10)]]
+)
+def test_xy_bounds_mercantile(args):
+    """test xy_bounds."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    expected = (
+        -1017529.7205322663,
+        7005300.768279833,
+        -978393.962050256,
+        7044436.526761846,
+    )
+    bounds = tms.xy_bounds(*args)
+
+    for a, b in zip(expected, bounds):
+        assert round(a - b, 7) == 0
+
+
+def test_tile_not_truncated():
+    """test tile."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    tile = tms.tile(20.6852, 40.1222, 9)
+    expected = (285, 193)
+    assert tile[0] == expected[0]
+    assert tile[1] == expected[1]
+
+
+def test_tile_truncate():
+    """Input is truncated"""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    assert tms.tile(-181.0, 0.0, 9, truncate=True) == tms.tile(-180.0, 0.0, 9)
+
+
+def test_tiles():
+    """Test tiles from bbox."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+
+    # replicate mercantile tests
+    # https://github.com/mapbox/mercantile/blob/master/tests/test_funcs.py#L115-L178
+    bounds = (-105, 39.99, -104.99, 40)
+    tiles = list(tms.tiles(*bounds, zooms=[14]))
+    expect = [
+        morecantile.Tile(x=3413, y=6202, z=14),
+        morecantile.Tile(x=3413, y=6203, z=14),
+    ]
+    assert sorted(tiles) == sorted(expect)
+
+    # Single zoom
+    bounds = (-105, 39.99, -104.99, 40)
+    tiles = list(tms.tiles(*bounds, zooms=14))
+    expect = [
+        morecantile.Tile(x=3413, y=6202, z=14),
+        morecantile.Tile(x=3413, y=6203, z=14),
+    ]
+    assert sorted(tiles) == sorted(expect)
+
+    # Input is truncated
+    assert list(tms.tiles(-181.0, 0.0, -170.0, 10.0, zooms=[2], truncate=True)) == list(
+        tms.tiles(-180.0, 0.0, -170.0, 10.0, zooms=[2])
+    )
+
+    # Antimeridian-crossing bounding boxes are handled
+    bounds = (175.0, 5.0, -175.0, 10.0)
+    assert len(list(tms.tiles(*bounds, zooms=[2]))) == 2
+
+    # Y is clamped to (0, 2 ** zoom - 1)
+    tiles = list(tms.tiles(-180, -90, 180, 90, [1]))
+    assert len(tiles) == 4
+    assert min(t.y for t in tiles) == 0
+    assert max(t.y for t in tiles) == 1
+
+    # tiles(bounds(tile)) gives the tile's children
+    t = morecantile.Tile(x=3413, y=6202, z=14)
+    res = list(tms.tiles(*tms.bounds(t), zooms=[15]))
+    assert len(res) == 4
+
+
+@pytest.mark.parametrize(
+    "t",
+    [
+        morecantile.Tile(x=3413, y=6202, z=14),
+        morecantile.Tile(486, 332, 10),
+        # morecantile.Tile(10, 10, 10), This is failing
+    ],
+)
+def test_tiles_roundtrip(t):
+    """Tiles(bounds(tile)) gives the tile."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    res = list(tms.tiles(*tms.bounds(t), zooms=[t.z]))
+    assert len(res) == 1
+    val = res.pop()
+    assert val.x == t.x
+    assert val.y == t.y
+    assert val.z == t.z


### PR DESCRIPTION
```
$ morecantile --help
Usage: morecantile [OPTIONS] COMMAND [ARGS]...

  Command line interface for the Morecantile Python package.

Options:
  -v, --verbose  Increase verbosity.
  -q, --quiet    Decrease verbosity.
  --version      Show the version and exit.
  --help         Show this message and exit.

Commands:
  custom          Create Custom TileMatrixSet
  shapes          Print the shapes of tiles as GeoJSON.
  tiles           Print tiles that overlap or contain a lng/lat point,
                  bounding box, or GeoJSON objects.
  tms             Print TileMatrixSet JSON document.
  tms-to-geojson  Print TileMatrixSet MatrixSet as GeoJSON.
```

```
$ morecantile tms --identifier EuropeanETRS89_LAEAQuad | morecantile tms-to-grid --level 5 --collect

$ morecantile shapes "[0, 0, 1]" --identifier EuropeanETRS89_LAEAQuad --precision 4 --projected

$ morecantile custom --epsg 3413 --extent -4194300 -4194300 4194300 4194300 --minzoom 0 --maxzoom 8 --tile-width 512 --tile-height 512 | morecantile tms-to-geojson --level 3 --projected --collect

# tiles in web mercator are defaults
$ rio bounds cog.tif | morecantile tiles 17 | morecantile shapes --collect
```