### PR TITLE
Remove pkg_resources and add `TILEMATRIXSET_DIRECTORY` env options

### DIFF
--- a/morecantile/__init__.py
+++ b/morecantile/__init__.py
@@ -8,10 +8,8 @@ Refs:
 
 """
 
-import pkg_resources
+__version__ = "1.3.0.post1"
 
 from .commons import Coords, CoordsBbox, Tile  # noqa
 from .defaults import tms  # noqa
 from .models import TileMatrixSet  # noqa
-
-version = pkg_resources.get_distribution(__package__).version

--- a/morecantile/scripts/cli.py
+++ b/morecantile/scripts/cli.py
@@ -46,7 +46,7 @@ def normalize_source(input):
 @click.group(help="Command line interface for the Morecantile Python package.")
 @click.option("--verbose", "-v", count=True, help="Increase verbosity.")
 @click.option("--quiet", "-q", count=True, help="Decrease verbosity.")
-@click.version_option(version=morecantile.version, message="%(version)s")
+@click.version_option(version=morecantile.__version__, message="%(version)s")
 @click.pass_context
 def cli(ctx, verbose, quiet):
     """Execute the main morecantile command"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 1.3.0.post1
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
+
+[bumpversion:file:morecantile/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'


### PR DESCRIPTION
This PR does: 
- remove pkg_resources which slows down module import (~0.3 s) 

#### Before
![before](https://user-images.githubusercontent.com/10407788/95359364-0eb92d00-0898-11eb-98f4-fabc7a35718c.png)

#### After
![after](https://user-images.githubusercontent.com/10407788/95359840-97d06400-0898-11eb-8adc-838ed354b5e4.png)


- add setup.cfg for bumpversion config (dev)
- add `TILEMATRIXSET_DIRECTORY` environement variable to load user TMS.
