### PR TITLE
Add mercantile to required installation package   

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,42 +3,28 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-        language_version: python3.7
-        args: ["--safe"]
+        language_version: python
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.4.2
     hooks:
       - id: isort
-        language_version: python3.7
+        language_version: python
 
   - repo: https://github.com/PyCQA/flake8
     rev: 3.8.3
     hooks:
       - id: flake8
-        language_version: python3.7
-        args: [
-            # E501 let black handle all line length decisions
-            # W503 black conflicts with "line break before operator" rule
-            # E203 black conflicts with "whitespace before ':'" rule
-            "--ignore=E501,W503,E203",
-          ]
+        language_version: python
 
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 5.1.1
     hooks:
       - id: pydocstyle
-        language_version: python3.7
-        args: [
-            # Check for docstring presence only
-            "--select=D1",
-            # Don't require docstrings for tests
-            '--match=(?!test).*\.py',
-          ]
+        language_version: python
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.812
     hooks:
       - id: mypy
-        language_version: python3.7
-        args: ["--no-strict-optional", "--ignore-missing-imports"]
+        language_version: python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+
+## 2.1.1 (TBD)
+
+* Add `mercantile` as required package (author @pratikyadav, https://github.com/developmentseed/morecantile/pull/47).
+
 ## 2.1.0 (2020-12-17)
 
 * add `zoom_level_strategy` option for `TileMatrixSet.zoom_for_res` to match GDAL 3.2.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Issues and pull requests are more than welcome.
 ```bash
 $ git clone https://github.com/developmentseed/morecantile.git
 $ cd morecantile
-$ pip install -e .[dev]
+$ pip install -e .["dev"]
 ```
 
 **Python3.7 only**

--- a/morecantile/commons.py
+++ b/morecantile/commons.py
@@ -4,8 +4,8 @@ from collections import OrderedDict, namedtuple
 
 from rasterio.coords import BoundingBox  # noqa
 
-_Tile = namedtuple("Tile", ["x", "y", "z"])
-_Coords = namedtuple("Coords", ["x", "y"])
+_Tile = namedtuple("_Tile", ["x", "y", "z"])
+_Coords = namedtuple("_Coords", ["x", "y"])
 
 
 class Coords(_Coords):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 rasterio>=1.1
 pydantic
+mercantile

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ commit = True
 tag = True
 tag_name = {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<suffix>.+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{suffix}
 	{major}.{minor}.{patch}
 
@@ -15,3 +15,23 @@ replace = version="{new_version}"
 [bumpversion:file:morecantile/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
+
+[isort]
+profile = black
+known_first_party = morecantile
+known_third_party = rasterio,pydantic,mercantile
+default_section = THIRDPARTY
+
+[flake8]
+ignore = E501,W503,E203
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
+max-line-length = 90
+
+[mypy]
+no_strict_optional = True
+ignore_missing_imports = True
+
+[pydocstyle]
+select = D1
+match = (?!test).*\.py
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 with open("README.md") as f:
     long_description = f.read()
 
-inst_reqs = ["rasterio>=1.1.7", "pydantic"]
+inst_reqs = ["rasterio>=1.1.7", "pydantic", "mercantile"]
 
 extra_reqs = {
     "test": ["mercantile", "pytest", "pytest-cov"],

--- a/tox.ini
+++ b/tox.ini
@@ -8,21 +8,6 @@ commands=
 deps=
     numpy
 
-# Lint
-[flake8]
-exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
-max-line-length = 90
-
-[mypy]
-no_strict_optional = True
-ignore_missing_imports = True
-
-[tool:isort]
-profile=black
-known_first_party = rio_tiler
-known_third_party = rasterio,mercantile,supermercado,affine
-default_section = THIRDPARTY
-
 # Release tooling
 [testenv:build]
 basepython = python3


### PR DESCRIPTION
I was trying to install morecantile to a new venv and spotted that it was missing mercantile package. 

```
$ mkvirtualenv -p python3.9.1 mor   

$ pip install morecantile  

$ morecantile --help                                                                                                                                                                                   127 ↵

Traceback (most recent call last):
  File "/Users/pratikyadav/.virtualenvs/mor/bin/morecantile", line 5, in <module>
    from morecantile.scripts.cli import cli
  File "/Users/pratikyadav/.virtualenvs/mor/lib/python3.9/site-packages/morecantile/scripts/cli.py", line 7, in <module>
    from mercantile.scripts import configure_logging, coords, iter_lines, normalize_input
ModuleNotFoundError: No module named 'mercantile'
```