### PR TITLE
remove mercantile from the dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/gdalversion.yml
+++ b/.github/workflows/gdalversion.yml
@@ -11,20 +11,26 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        gdal-image: ["osgeo/gdal:ubuntu-small-latest", "osgeo/gdal:ubuntu-small-3.1.3", "geographica/gdal2:2.4.3"]
+        rasterio-version: ["1.1.8", ">=1.2"]
+        # Rasterio 1.1.8 wheels come with GDAL 2
+        # Rasterio 1.2.3 wheels come with GDAL 3.2
       fail-fast: false
 
-    container: ${{ matrix.gdal-image }}
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+
       - name: Install dependencies
         run: |
-          apt-get update -y
-          apt-get install python3-pip -y
-          python3 -m pip install .["test"] --no-binary rasterio
+          python -m pip install --upgrade pip
+          python -m pip install .["test"] rasterio==${{ matrix.rasterio-version }}
 
       - name: Run Test
-        run: python3 -m pytest --cov morecantile --cov-report term-missing --ignore=venv
+        run: python -m pytest --cov morecantile --cov-report term-missing --ignore=venv
         env:
           LANG: C.UTF-8
           LC_ALL: C.UTF-8

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 
 ## 2.1.1 (TBD)
 
-* Add `mercantile` as required package (author @pratikyadav, https://github.com/developmentseed/morecantile/pull/47).
+* remove `mercantile` dependency.
 
 ## 2.1.0 (2020-12-17)
 

--- a/morecantile/scripts/cli.py
+++ b/morecantile/scripts/cli.py
@@ -2,14 +2,50 @@
 
 import json
 import logging
+import sys
 
 import click
-from mercantile.scripts import configure_logging, coords, iter_lines, normalize_input
 from rasterio.crs import CRS
+from rasterio.rio.helpers import coords
 
 import morecantile
 
 logger = logging.getLogger(__name__)
+
+
+def configure_logging(verbosity):
+    """Configure log verbosity.
+
+    Original code from https://github.com/mapbox/mercantile/blob/71bb3dbdaeb4ccf0e14bfabf1f58d36465cd5289/mercantile/scripts/__init__.py#L13-L26
+    License: BSD-3 Original work Copyright 2021 Mapbox
+    """
+    log_level = max(10, 30 - 10 * verbosity)
+    logging.basicConfig(stream=sys.stderr, level=log_level)
+
+
+def normalize_input(input):
+    """Normalize file or string input.
+
+    Original code from https://github.com/mapbox/mercantile/blob/71bb3dbdaeb4ccf0e14bfabf1f58d36465cd5289/mercantile/scripts/__init__.py#L34-L40
+    License: BSD-3 Original work Copyright 2021 Mapbox
+    """
+    try:
+        src = click.open_file(input).readlines()
+    except IOError:
+        src = [input]
+    return src
+
+
+def iter_lines(lines):
+    """Iterate over lines of input, stripping and skipping.
+
+    Original code from https://github.com/mapbox/mercantile/blob/71bb3dbdaeb4ccf0e14bfabf1f58d36465cd5289/mercantile/scripts/__init__.py#L43-L48
+    License: BSD-3 Original work Copyright 2021 Mapbox
+    """
+    for line in lines:
+        line = line.strip()
+        if line:
+            yield line
 
 
 def normalize_source(input):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 with open("README.md") as f:
     long_description = f.read()
 
-inst_reqs = ["rasterio>=1.1.7", "pydantic", "mercantile"]
+inst_reqs = ["rasterio>=1.1.7", "pydantic"]
 
 extra_reqs = {
     "test": ["mercantile", "pytest", "pytest-cov"],

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: GIS",
     ],
     keywords="GIS",


### PR DESCRIPTION
closes #50 
closes #49 

we were relying on mercantile for the CLI. the methods used from mercantile were `scripts` method and subject to change in mercantile code base. I think it's safer to bring the function over to avoid breaking changes 

I'm sorry @pratikyadav