### PR TITLE
radd PointOutsideTMS warning when user do operation outside TMS bounds and fix GDAL related test failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 ## 2.1.1 (TBD)
 
 * remove `mercantile` dependency.
+* raise `PointOutsideTMSBounds` warning when user is doing operations outside TMS bounds.
+* fix wrong `xy_bbox` when `tms.boundingBox` use a specific CRS.
 
 ## 2.1.0 (2020-12-17)
 

--- a/morecantile/errors.py
+++ b/morecantile/errors.py
@@ -15,3 +15,7 @@ class InvalidLatitudeError(MorecantileError):
 
 class TileArgParsingError(MorecantileError):
     """Raised when errors occur in parsing a function's tile arg(s)"""
+
+
+class PointOutsideTMSBounds(UserWarning):
+    """Point is outside TMS bounds."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""``pytest`` configuration."""
+
+import pytest
+from rasterio.env import GDALVersion
+
+# Define helpers to skip tests based on GDAL version
+gdal_version = GDALVersion.runtime()
+
+requires_gdal_lt_3 = pytest.mark.skipif(
+    gdal_version.__lt__("3.0"), reason="Requires GDAL 1.x/2.x"
+)
+
+requires_gdal3 = pytest.mark.skipif(
+    not gdal_version.at_least("3.0"), reason="Requires GDAL 3.0.x"
+)


### PR DESCRIPTION
this PR does:
- [x] resolve test failure between GDAL3 and GDAL2
- [x] add  `PointOutsideTMS` warning when doing operation outside TMS bounds
- [x] Fix issues when tms extent is set using a specific CRS 