### PR TITLE
Import rasterio within the `rasterio_crs` property to speedup startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+## 3.0.0a1 (2021-09-17)
+
+* only import rasterio if needed (https://github.com/developmentseed/morecantile/pull/66)
+
 ## 3.0.0a0 (2021-09-09)
 
 * add `.rasterio_crs` properties to TMS for compatibility with rasterio (https://github.com/developmentseed/morecantile/pull/58)

--- a/morecantile/__init__.py
+++ b/morecantile/__init__.py
@@ -8,7 +8,7 @@ Refs:
 
 """
 
-__version__ = "3.0.0a0"
+__version__ = "3.0.0a1"
 
 from .commons import BoundingBox, Coords, Tile  # noqa
 from .defaults import tms  # noqa

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -1,4 +1,5 @@
 """Pydantic modules for OGC TileMatrixSets (https://www.ogc.org/standards/tms)"""
+
 import math
 import warnings
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -19,13 +19,6 @@ from .utils import (
     truncate_lnglat,
 )
 
-try:
-    from rasterio.crs import CRS as rasterioCRS
-    from rasterio.env import GDALVersion
-except ModuleNotFoundError:
-    rasterioCRS = None
-    GDALVersion = None
-
 NumType = Union[float, int]
 BoundsType = Tuple[NumType, NumType]
 LL_EPSILON = 1e-11
@@ -180,17 +173,16 @@ class TileMatrixSet(BaseModel):
         return self.supportedCRS
 
     @property
-    def rasterio_crs(self) -> rasterioCRS:
+    def rasterio_crs(self):
         """Return rasterio CRS."""
-        if not rasterioCRS:
-            raise ModuleNotFoundError(
-                "Rasterio has to be installed to use `rasterio_crs` method."
-            )
+
+        import rasterio
+        from rasterio.env import GDALVersion
 
         if GDALVersion.runtime().major < 3:
-            return rasterioCRS.from_wkt(self.crs.to_wkt(WktVersion.WKT1_GDAL))
+            return rasterio.crs.CRS.from_wkt(self.crs.to_wkt(WktVersion.WKT1_GDAL))
         else:
-            return rasterioCRS.from_wkt(self.crs.to_wkt())
+            return rasterio.crs.CRS.from_wkt(self.crs.to_wkt())
 
     @property
     def minzoom(self) -> int:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 
 [bumpversion]
-current_version = 3.0.0a0
+current_version = 3.0.0a1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extra_reqs = {
 
 setup(
     name="morecantile",
-    version="3.0.0a0",
+    version="3.0.0a1",
     python_requires=">=3.7",
     description=u"""Construct and use map tile grids (a.k.a TileMatrixSet / TMS).""",
     long_description=long_description,


### PR DESCRIPTION
ref https://github.com/developmentseed/morecantile/issues/64#issuecomment-921648142

as mentioned in ☝️ Importing rasterio if not needed will slow down the startup. 

### Before 
```python
%time import morecantile
CPU times: user 258 ms, sys: 35.9 ms, total: 294 ms
Wall time: 360 ms

tms = morecantile.tms.get("WebMercatorQuad")

%time tms.rasterio_crs
CPU times: user 3.11 ms, sys: 479 µs, total: 3.59 ms
Wall time: 3.59 ms
```

### With this PR
```python
%time import morecantile
CPU times: user 102 ms, sys: 12.5 ms, total: 114 ms
Wall time: 114 ms

tms = morecantile.tms.get("WebMercatorQuad")

%time tms.rasterio_crs
CPU times: user 158 ms, sys: 33.6 ms, total: 192 ms
Wall time: 258 ms

# makes sure nothing happens after
%time tms.rasterio_crs
CPU times: user 108 µs, sys: 16 µs, total: 124 µs
Wall time: 125 µs
```

in ☝️ we can see that importing rasterio within the `rasterio_crs` only slows down the first call to the properties in addition of speeding up the general morecantile import