### PR TITLE
Planetary projection fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+## 3.0.2 (2021-11-12)
+
+* add `_geographic_crs` definition in `__init__` to make sure it's initialized from user input (author @davenquinn, https://github.com/developmentseed/morecantile/pull/72)
+
 ## 3.0.1 (2021-11-10)
 
 * rename `_to_wgs84` and `_from_wgs84` private attributes to `_to_geographic` and `_from_geographic` (https://github.com/developmentseed/morecantile/pull/68)

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -145,6 +145,7 @@ class TileMatrixSet(BaseModel):
 
         self._is_quadtree = check_quadkey_support(self.tileMatrix)
 
+        self._geographic_crs = data.get("_geographic_crs", WGS84_CRS)
         try:
             self._to_geographic = Transformer.from_crs(
                 self.supportedCRS, self._geographic_crs, always_xy=True

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -146,6 +146,7 @@ class TileMatrixSet(BaseModel):
         self._is_quadtree = check_quadkey_support(self.tileMatrix)
 
         self._geographic_crs = data.get("_geographic_crs", WGS84_CRS)
+
         try:
             self._to_geographic = Transformer.from_crs(
                 self.supportedCRS, self._geographic_crs, always_xy=True


### PR DESCRIPTION
Following up on #67, I tested the changes merged in #68 and found them to _almost_ work, except that the private `_geographic_crs` attr wasn't properly initialized (apparently that has to happen manually in `__init__`). So I fixed that, and added two tests:

1. Create a Mars equivalent to the global web mercator TMS
2. Create a localized TMS centered around the Perseverance landing site

Thanks for your quick action on these suggestions. This is helpful for planetary scientists!