### PR TITLE
add GoogleMapsCompatible TMS to match GDAL TMS

### DIFF
--- a/morecantile/data/GoogleMapsCompatible.json
+++ b/morecantile/data/GoogleMapsCompatible.json
@@ -1,0 +1,346 @@
+{
+    "type": "TileMatrixSetType",
+    "title": "Google Maps Compatible for the World",
+    "identifier": "WebMercatorQuad",
+    "boundingBox": {
+        "type": "BoundingBoxType",
+        "crs": "urn:ogc:def:crs:EPSG::3857",
+        "lowerCorner": [
+            -20037508.342789244,
+            -20037508.342789244
+        ],
+        "upperCorner": [
+            20037508.342789244,
+            20037508.342789244
+        ]
+    },
+    "supportedCRS": "urn:ogc:def:crs:EPSG::3857",
+    "wellKnownScaleSet": "http://www.opengis.net/def/wkss/OGC/1.0/GoogleMapsCompatible",
+    "tileMatrix": [
+        {
+            "type": "TileMatrixType",
+            "identifier": "0",
+            "scaleDenominator": 559082264.0287178,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 1,
+            "matrixHeight": 1
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "1",
+            "scaleDenominator": 279541132.0143589,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 2,
+            "matrixHeight": 2
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "2",
+            "scaleDenominator": 139770566.00717944,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 4,
+            "matrixHeight": 4
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "3",
+            "scaleDenominator": 69885283.00358972,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 8,
+            "matrixHeight": 8
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "4",
+            "scaleDenominator": 34942641.50179486,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 16,
+            "matrixHeight": 16
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "5",
+            "scaleDenominator": 17471320.75089743,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 32,
+            "matrixHeight": 32
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "6",
+            "scaleDenominator": 8735660.375448715,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 64,
+            "matrixHeight": 64
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "7",
+            "scaleDenominator": 4367830.1877243575,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 128,
+            "matrixHeight": 128
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "8",
+            "scaleDenominator": 2183915.0938621787,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 256,
+            "matrixHeight": 256
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "9",
+            "scaleDenominator": 1091957.5469310894,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 512,
+            "matrixHeight": 512
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "10",
+            "scaleDenominator": 545978.7734655447,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 1024,
+            "matrixHeight": 1024
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "11",
+            "scaleDenominator": 272989.38673277234,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 2048,
+            "matrixHeight": 2048
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "12",
+            "scaleDenominator": 136494.69336638617,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 4096,
+            "matrixHeight": 4096
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "13",
+            "scaleDenominator": 68247.34668319309,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 8192,
+            "matrixHeight": 8192
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "14",
+            "scaleDenominator": 34123.67334159654,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 16384,
+            "matrixHeight": 16384
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "15",
+            "scaleDenominator": 17061.83667079827,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 32768,
+            "matrixHeight": 32768
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "16",
+            "scaleDenominator": 8530.918335399136,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 65536,
+            "matrixHeight": 65536
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "17",
+            "scaleDenominator": 4265.459167699568,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 131072,
+            "matrixHeight": 131072
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "18",
+            "scaleDenominator": 2132.729583849784,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 262144,
+            "matrixHeight": 262144
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "19",
+            "scaleDenominator": 1066.364791924892,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 524288,
+            "matrixHeight": 524288
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "20",
+            "scaleDenominator": 533.182395962446,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 1048576,
+            "matrixHeight": 1048576
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "21",
+            "scaleDenominator": 266.591197981223,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 2097152,
+            "matrixHeight": 2097152
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "22",
+            "scaleDenominator": 133.2955989906115,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 4194304,
+            "matrixHeight": 4194304
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "23",
+            "scaleDenominator": 66.64779949530575,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 8388608,
+            "matrixHeight": 8388608
+        },
+        {
+            "type": "TileMatrixType",
+            "identifier": "24",
+            "scaleDenominator": 33.323899747652874,
+            "topLeftCorner": [
+                -20037508.342789244,
+                20037508.342789244
+            ],
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "matrixWidth": 16777216,
+            "matrixHeight": 16777216
+        }
+    ]
+}


### PR DESCRIPTION
ref https://github.com/developmentseed/titiler/issues/431#issuecomment-1038915232

There are small differences between GDAL `GoogleMapsCompatible` and the `WebMercatorQuad` TMS defined by morecantile. It all comes down to the value of the earth `HALF_CIRCUMFERENCE` defined as 

```
# GDAL
https://github.com/OSGeo/gdal/blob/35c07b18316b4b6d238f6d60b82c31e25662ad27/gcore/tilematrixset.cpp#L79
>> 20037508.342789244

# Morecantile 
https://github.com/developmentseed/morecantile/blob/master/morecantile/data/WebMercatorQuad.json#L9
>> 20037508.3427892
```

I'm not sure I want to modify the `WebMercatorQuad` so IMO, adding a new TMS seems to be the better solution. 

Note: we need a better name than GoogleMapsCompatible
