### PR TITLE
Add missing methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 
 ## 3.1.0 (TBD)
 
-* add `parent`, `children`, `neighbors`, `extrema`, `is_valid` methods (https://github.com/developmentseed/morecantile/pull/82)
+* add `parent`, `children`, `neighbors`, `minmax`, `is_valid` methods (https://github.com/developmentseed/morecantile/pull/82)
 
 **breaking changes**
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 
 ## 3.1.0 (TBD)
 
+* add `parent`, `children`, `neighbors`, `extrema`, `is_valid` methods (https://github.com/developmentseed/morecantile/pull/82)
+
 **breaking changes**
 
 * update `WebMercatorQuad` TMS to match `mercantile` and `GDAL` definition of the half-earth value

--- a/morecantile/errors.py
+++ b/morecantile/errors.py
@@ -27,3 +27,7 @@ class NoQuadkeySupport(MorecantileError):
 
 class QuadKeyError(MorecantileError):
     """Raised when errors occur in computing or parsing quad keys"""
+
+
+class InvalidZoomError(MorecantileError):
+    """Raised when input zoom is invalid."""

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -931,10 +931,8 @@ class TileMatrixSet(BaseModel):
 
         return Tile(xtile, ytile, i + 1)
 
-    def extrema(self, zoom: int) -> Dict:
+    def minmax(self, zoom: int) -> Dict:
         """Return TileMatrix Extrema.
-
-        Note: Equivalent of `mercantile.minmax`
 
         Parameters
         ----------
@@ -959,7 +957,7 @@ class TileMatrixSet(BaseModel):
         if t.z < self.minzoom:
             return False
 
-        extrema = self.extrema(t.z)
+        extrema = self.minmax(t.z)
         validx = extrema["x"]["min"] <= t.x <= extrema["x"]["max"]
         validy = extrema["y"]["min"] <= t.y <= extrema["y"]["max"]
 
@@ -985,7 +983,7 @@ class TileMatrixSet(BaseModel):
 
         """
         t = _parse_tile_arg(*tile)
-        extrema = self.extrema(t.z)
+        extrema = self.minmax(t.z)
 
         tiles = []
         for i in [-1, 0, 1]:


### PR DESCRIPTION
closes https://github.com/developmentseed/morecantile/issues/48

add `parent`, `children`, `neighbors`, `extrema`, `is_valid` methods

There are some difference with how we get the parent/children in comparison to mercantile method because we can't really on only the 1 <-> 4 schema of WebMercator. The general idea is to get the bounds from the tile and then find tile(s) for the bounds at the given zoom level. Tests give the same result as for mercantile 🤷‍♂️ 