### PR TITLE
Clip the adjusted zoom to the provided min/max z in `zoom_for_res`

### DIFF
--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -418,14 +418,14 @@ class TileMatrixSet(BaseModel):
 
         if zoom_level > 0 and abs(res - matrix_res) / matrix_res > 1e-8:
             if zoom_level_strategy.lower() == "lower":
-                zoom_level -= 1
+                zoom_level = max(zoom_level - 1, min_z)
             elif zoom_level_strategy.lower() == "upper":
-                pass
+                zoom_level = min(zoom_level, max_z)
             elif zoom_level_strategy.lower() == "auto":
-                if (self._resolution(self.matrix(zoom_level - 1)) / res) < (
+                if (self._resolution(self.matrix(max(zoom_level - 1, min_z))) / res) < (
                     res / matrix_res
                 ):
-                    zoom_level -= 1
+                    zoom_level = max(zoom_level - 1, min_z)
             else:
                 raise ValueError(
                     f"Invalid strategy: {zoom_level_strategy}. Should be one of lower|upper|auto"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -269,6 +269,7 @@ def test_zoom_for_res():
         extent, crs, identifier="MyCustomTmsEPSG3857", minzoom=6
     )
     assert tms.zoom_for_res(10) == 14
+    assert tms.zoom_for_res(5_000) == 6
 
 
 def test_schema():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -269,7 +269,7 @@ def test_zoom_for_res():
         extent, crs, identifier="MyCustomTmsEPSG3857", minzoom=6
     )
     assert tms.zoom_for_res(10) == 14
-    assert tms.zoom_for_res(5_000) == 6
+    assert tms.zoom_for_res(5000) == 6
 
 
 def test_schema():


### PR DESCRIPTION
Otherwise a zoom could be chosen that's not in the TileMatrixSet.

## What I am changing
This change ensures that a zoom returned by `zoom_for_res` is within the range provided by the `min_z` & `max_z` arguments (or the `TileMatrixSet`'s `minzoom` & `maxzoom`).
Without this change an exception is raised when the nearest zoom to the `res` argument is less than the TMS `minzoom` (when using the default `zoom_level_strategy` of `"auto"`).

## How I did it
I added a test case demonstrating the bug, and then clipped the `zoom_level` to the provided min/max z.

## How you can test it
Updated the unit test for `zoom_for_res`. 

An example WMTS with a TileMatrixSet that has a minimum zoom > 0: https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/orthos2021/MapServer/WMTS/1.0.0/WMTSCapabilities.xml

## Related Issues
N/A