### PR TITLE
allow for non-earth scaleDenominators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+## NEXT (TDB)
+
+* fix `utils.meters_per_unit` for non earth bodies (author @AndrewAnnex, https://github.com/developmentseed/morecantile/pull/92)
+
 ## 3.2.2 (2022-11-25)
 
 * add `morecantile.defaults.TileMatrixSets` in export

--- a/morecantile/utils.py
+++ b/morecantile/utils.py
@@ -52,7 +52,7 @@ def meters_per_unit(crs: CRS) -> float:
     """
     unit_factors = {
         "metre": 1.0,
-        "degree": 2 * math.pi * 6378137 / 360.0,
+        "degree": 2 * math.pi * crs.ellipsoid.semi_major_metre / 360.0,
         "foot": 0.3048,
         "US survey foot": 0.30480060960121924,
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ from morecantile import utils
 
 
 @pytest.mark.parametrize(
-    "epsg,unit",
+    "crs,unit",
     [
         (CRS.from_epsg(4326), 2 * math.pi * 6378137 / 360.0),
         (CRS.from_epsg(3857), 1.0),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,25 @@ from morecantile import utils
 @pytest.mark.parametrize(
     "epsg,unit",
     [
-        (4326, 2 * math.pi * 6378137 / 360.0),
-        (3857, 1.0),
-        (2276, 0.30480060960121924),
-        (2222, 0.3048),
+        (CRS.from_epsg(4326), 2 * math.pi * 6378137 / 360.0),
+        (CRS.from_epsg(3857), 1.0),
+        (CRS.from_epsg(2276), 0.30480060960121924),
+        (CRS.from_epsg(2222), 0.3048),
+        # Mars in Meter
+        (
+            CRS.from_proj4(
+                "+proj=tmerc +lat_0=17 +lon_0=76.5 +k=0.9996 +x_0=0 +y_0=0 +a=3396190 +b=3376200 +units=m +no_defs"
+            ),
+            1.0,
+        ),
+        # Mars in Degrees
+        # proj4 from https://github.com/AndrewAnnex/planetcantile/blob/5ea2577f5dc4a3bc91b0443ef0633a5f89b15e03/planetcantile/data/generate.py#L45-L47
+        (
+            CRS.from_proj4("+proj=longlat +R=3396190 +no_defs +type=crs"),
+            2 * math.pi * 3396190 / 360.0,
+        ),
     ],
 )
-def test_mpu(epsg, unit):
+def test_mpu(crs, unit):
     """test meters_per_unit."""
-    assert utils.meters_per_unit(CRS.from_epsg(epsg)) == unit
+    assert utils.meters_per_unit(crs) == unit


### PR DESCRIPTION
Updated the meters_per_unit utility function to grab the semi major axis length directly from the CRS ellipsoid. This will help with making TMS specs for other planets more correct. I should look to update the mars related tests to ensure things are working...  