### PR TITLE
adds ability to export non-EPSG CRSs URIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 
-## NEXT (TDB)
+## 3.2.3 (2022-12-13)
 
 * fix `utils.meters_per_unit` for non earth bodies (author @AndrewAnnex, https://github.com/developmentseed/morecantile/pull/92)
+* fix `CRS_to_uri` function to adds ability to export non-EPSG CRSs URIs (author @AndrewAnnex, https://github.com/developmentseed/morecantile/pull/93)
 
 ## 3.2.2 (2022-11-25)
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -75,7 +75,7 @@ def CRS_to_uri(crs: CRS) -> str:
     authority, code = crs.to_authority(min_confidence=20)
     # if we have a version number in the authority, split it out
     if '_' in authority:
-        authority, version = authority
+        authority, version = authority.split('_')
     return f"http://www.opengis.net/def/crs/{authority}/{version}/{code}"
 
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -71,9 +71,9 @@ class CRSType(CRS, str):
 
 def CRS_to_uri(crs: CRS) -> str:
     """Convert CRS to URI."""
-    authority = 'EPSG'
+    authority = "EPSG"
     code = None
-    version = 0
+    version = "0"
     # attempt to grab the authority, version, and code from the CRS
     authority_code = crs.to_authority(min_confidence=20)
     if authority_code is not None:

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -72,7 +72,7 @@ class CRSType(CRS, str):
 def CRS_to_uri(crs: CRS) -> str:
     """Convert CRS to URI."""
     version = 0
-    authority, code = crs.to_authority()
+    authority, code = crs.to_authority(min_confidence=20)
     # if we have a version number in the authority, split it out
     if '_' in authority:
         authority, version = authority

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -71,11 +71,16 @@ class CRSType(CRS, str):
 
 def CRS_to_uri(crs: CRS) -> str:
     """Convert CRS to URI."""
+    authority = 'EPSG'
+    code = None
     version = 0
-    authority, code = crs.to_authority(min_confidence=20)
-    # if we have a version number in the authority, split it out
-    if '_' in authority:
-        authority, version = authority.split('_')
+    # attempt to grab the authority, version, and code from the CRS
+    authority_code = crs.to_authority(min_confidence=20)
+    if authority_code is not None:
+        authority, code = authority_code
+        # if we have a version number in the authority, split it out
+        if "_" in authority:
+            authority, version = authority.split("_")
     return f"http://www.opengis.net/def/crs/{authority}/{version}/{code}"
 
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -71,8 +71,12 @@ class CRSType(CRS, str):
 
 def CRS_to_uri(crs: CRS) -> str:
     """Convert CRS to URI."""
-    epsg_code = crs.to_epsg()
-    return f"http://www.opengis.net/def/crs/EPSG/0/{epsg_code}"
+    version = 0
+    authority, code = crs.to_authority()
+    # if we have a version number in the authority, split it out
+    if '_' in authority:
+        authority, version = authority
+    return f"http://www.opengis.net/def/crs/{authority}/{version}/{code}"
 
 
 def crs_axis_inverted(crs: CRS) -> bool:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -397,3 +397,9 @@ def test_crs_uris(authority, code, result):
         morecantile.models.CRS_to_uri(CRS((authority, code)))
         == f"http://www.opengis.net/def/crs/{result}"
     )
+
+
+@pytest.mark.parametrize("tilematrixset", morecantile.tms.list())
+def test_crs_uris_for_defaults(tilematrixset):
+    t = morecantile.tms.get(tilematrixset)
+    assert t.supportedCRS == morecantile.models.CRS_to_uri(t.crs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -379,3 +379,18 @@ def test_mars_local_tms():
 def test_inverted_tms(id, result):
     """Make sure _invert_axis return the correct result."""
     assert morecantile.tms.get(id)._invert_axis == result
+
+
+@pytest.mark.parametrize(
+    "authority,code,result",
+    [
+        ("EPSG", "4326", "EPSG/0/4326"),
+        ("ESRI", "102001", "ESRI/0/102001"),
+        ("IAU_2015", "49910", "IAU/2015/49910"),
+        ("IGNF", "AMANU49", "IGNF/0/AMANU49"),
+        ("NKG", "ETRF00", "NKG/0/ETRF00"),
+        ("OGC", "CRS84", "OGC/0/CRS84")
+    ],
+)
+def test_crs_uris(authority, code, result):
+    assert morecantile.models.CRS_to_uri(CRS((authority, code))) == f'http://www.opengis.net/def/crs/{result}'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -389,8 +389,11 @@ def test_inverted_tms(id, result):
         ("IAU_2015", "49910", "IAU/2015/49910"),
         ("IGNF", "AMANU49", "IGNF/0/AMANU49"),
         ("NKG", "ETRF00", "NKG/0/ETRF00"),
-        ("OGC", "CRS84", "OGC/0/CRS84")
+        ("OGC", "CRS84", "OGC/0/CRS84"),
     ],
 )
 def test_crs_uris(authority, code, result):
-    assert morecantile.models.CRS_to_uri(CRS((authority, code))) == f'http://www.opengis.net/def/crs/{result}'
+    assert (
+        morecantile.models.CRS_to_uri(CRS((authority, code)))
+        == f"http://www.opengis.net/def/crs/{result}"
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -292,8 +292,7 @@ def test_schema():
     assert tms.schema_json()
     assert tms.dict(exclude_none=True)
     json_doc = json.loads(tms.json(exclude_none=True))
-    # We cannot translate PROJ4 to epsg so it's set to None
-    assert json_doc["supportedCRS"] == "http://www.opengis.net/def/crs/EPSG/0/None"
+    assert json_doc["supportedCRS"] == "http://www.opengis.net/def/crs/IAU/2015/49930"
 
     crs = CRS.from_epsg(3031)
     extent = [-948.75, -543592.47, 5817.41, -3333128.95]  # From https:///epsg.io/3031


### PR DESCRIPTION
grabs the authority, version and code from the CRS directly to encode the URIs. Related to #92 but can be merged separately. I'm not aware of any issues this would cause but I am open to hearing about them