### PR TITLE
Remove assumption from `tiles()` method that tile rows/cols are ordered…

### DIFF
--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -12,7 +12,6 @@ from pyproj.exceptions import ProjError
 from morecantile.commons import BoundingBox, Coords, Tile
 from morecantile.errors import (
     InvalidZoomError,
-    MorecantileError,
     NoQuadkeySupport,
     PointOutsideTMSBounds,
     QuadKeyError,
@@ -782,16 +781,11 @@ class TileMatrixSet(BaseModel):
                     w + LL_EPSILON, n - LL_EPSILON, z
                 )  # Not in mercantile
                 se_tile = self.tile(e - LL_EPSILON, s + LL_EPSILON, z)
-                minx, maxx = (
-                    (nw_tile.x, se_tile.x)
-                    if nw_tile.x < se_tile.x
-                    else (se_tile.x, nw_tile.x)
-                )
-                miny, maxy = (
-                    (nw_tile.y, se_tile.y)
-                    if nw_tile.y < se_tile.y
-                    else (se_tile.y, nw_tile.y)
-                )
+
+                minx = min(nw_tile.x, se_tile.x)
+                maxx = max(nw_tile.x, se_tile.x)
+                miny = min(nw_tile.y, se_tile.y)
+                maxy = max(nw_tile.y, se_tile.y)
 
                 for i in range(minx, maxx + 1):
                     for j in range(miny, maxy + 1):

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -744,7 +744,7 @@ class TileMatrixSet(BaseModel):
         zooms : int or sequence of int
             One or more zoom levels.
         truncate : bool, optional
-            Whether or not to truncate inputs to web mercator limits.
+            Whether or not to truncate inputs to TMS limits.
 
         Yields
         ------
@@ -778,13 +778,23 @@ class TileMatrixSet(BaseModel):
             n = min(self.bbox.top, n)
 
             for z in zooms:
-                ul_tile = self.tile(
+                nw_tile = self.tile(
                     w + LL_EPSILON, n - LL_EPSILON, z
                 )  # Not in mercantile
-                lr_tile = self.tile(e - LL_EPSILON, s + LL_EPSILON, z)
+                se_tile = self.tile(e - LL_EPSILON, s + LL_EPSILON, z)
+                minx, maxx = (
+                    (nw_tile.x, se_tile.x)
+                    if nw_tile.x < se_tile.x
+                    else (se_tile.x, nw_tile.x)
+                )
+                miny, maxy = (
+                    (nw_tile.y, se_tile.y)
+                    if nw_tile.y < se_tile.y
+                    else (se_tile.y, nw_tile.y)
+                )
 
-                for i in range(ul_tile.x, lr_tile.x + 1):
-                    for j in range(ul_tile.y, lr_tile.y + 1):
+                for i in range(minx, maxx + 1):
+                    for j in range(miny, maxy + 1):
                         yield Tile(i, j, z)
 
     def feature(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ select = [
     "D1",  # pydocstyle errors
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
+    "F",  # flake8
     "C",  # flake8-comprehensions
     "B",  # flake8-bugbear
 ]

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -390,7 +390,9 @@ def test_tiles():
 
 def test_tiles_for_tms_with_non_standard_row_col_order():
     """Test tiles from bbox when TMS has non-standard row/col alignment with lat/lon."""
-    crs = CRS.from_proj4(f"+proj=s2 +lat_0=0.0 +lon_0=-90.0 +ellps=WGS84 +UVtoST=quadratic")
+    crs = CRS.from_proj4(
+        "+proj=s2 +lat_0=0.0 +lon_0=-90.0 +ellps=WGS84 +UVtoST=quadratic"
+    )
     extent = [0.0, 0.0, 1.0, 1.0]
     s2f4 = morecantile.TileMatrixSet.custom(extent, crs, identifier="S2F4")
     overlapping_tiles = s2f4.tiles(-100, 27, -95, 33, [6])

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -388,6 +388,15 @@ def test_tiles():
     assert len(list(tms.tiles(*bounds, zooms=[2]))) == 2
 
 
+def test_tiles_for_tms_with_non_standard_row_col_order():
+    """Test tiles from bbox when TMS has non-standard row/col alignment with lat/lon."""
+    crs = CRS.from_proj4(f"+proj=s2 +lat_0=0.0 +lon_0=-90.0 +ellps=WGS84 +UVtoST=quadratic")
+    extent = [0.0, 0.0, 1.0, 1.0]
+    s2f4 = morecantile.TileMatrixSet.custom(extent, crs, identifier="S2F4")
+    overlapping_tiles = s2f4.tiles(-100, 27, -95, 33, [6])
+    assert len(list(overlapping_tiles)) == 30
+
+
 def test_global_tiles_clamped():
     """Y is clamped to (0, 2 ** zoom - 1)."""
     tms = morecantile.tms.get("WebMercatorQuad")


### PR DESCRIPTION
… west-east and north-south

A TileMatrixSet created for a projection like an S2 face does not comply with this assumption.

## What I am changing
<!-- What were the high-level goals of the change? -->
The `tiles()` method did not return the expected tiles overlapping a bbox for a tile matrix created using an S2 face projection (see [this](https://s2geometry.io/resources/earthcube)).

My change removes the assumption that the bounds of the tile matrix set must be aligned such that the top-left corner corresponds to the geographic north-west etc.

## How I did it
Simply check the tile indices of the north-west and south-east tiles and iterate according to which is greater.

## How you can test it
One can test using a TileMatrixSet created like this:
```python
crs = CRS.from_proj4(f"+proj=s2 +lat_0=0.0 +lon_0=-90.0 +ellps=WGS84 +UVtoST=quadratic")
extent = [0.0, 0.0, 1.0, 1.0]
s2f4 = TileMatrixSet.custom(extent, crs, identifier="S2F4")
overlapping_tiles = s2f4.tiles(-100, 27, -95, 33, [6])
assert len(overlapping_tiles) > 1 
```