### PR TITLE
fix docstring for children method

### DIFF
--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -1067,8 +1067,8 @@ class TileMatrixSet(BaseModel):
         tile : Tile or sequence of int
             May be be either an instance of Tile or 3 ints, X, Y, Z.
         zoom : int, optional
-            Determines the *zoom* level of the returned parent tile.
-            This defaults to one lower than the tile (the immediate parent).
+            Determines the *zoom* level of the returned child tiles.
+            This defaults to one higher than the tile (the immediate children).
 
         Returns
         -------


### PR DESCRIPTION
Small improvement on wording in `children` docstring. Fixes an artifact from copy pasting from the `parent` method docstring I guess.
