### PR TITLE
add LRU Cache on top of bbox property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * remove `NZTM2000` TileMatrixSet (ref: https://github.com/developmentseed/morecantile/issues/103)
 * add `rasterio_geographic_crs` to export TMS's geographic CRS to Rasterio's CRS object (author @AndrewAnnex, https://github.com/developmentseed/morecantile/pull/109)
 * add `geographic_crs` property in the TileMatrixSet model to return the private `_geographic_crs` attribute
+* add cache LRU layer on top of `TileMatrixSet.bbox` method
 
 ## 3.3.0 (2023-03-09)
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -4,6 +4,8 @@ import math
 import warnings
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
+from cachetools import LRUCache, cached
+from cachetools.keys import hashkey
 from pydantic import AnyHttpUrl, BaseModel, Field, PrivateAttr, validator
 from pyproj import CRS, Transformer
 from pyproj.exceptions import ProjError
@@ -732,6 +734,10 @@ class TileMatrixSet(BaseModel):
         return BoundingBox(left, bottom, right, top)
 
     @property
+    @cached(  # type: ignore
+        LRUCache(maxsize=512),
+        key=lambda self: hashkey(self.id, self.tileMatrices[0].pointOfOrigin),
+    )
     def bbox(self):
         """Return TMS bounding box in geographic coordinate reference system."""
         left, bottom, right, top = self.xy_bbox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "attrs",
     "pyproj~=3.1",
     "pydantic",
+    "cachetools",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
ref #112 

```python
# Without Cache
import morecantile
tms = morecantile.tms.get("WebMercatorQuad")

%timeit tms.bbox
15 µs ± 16.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

# With Cache
import morecantile
tms = morecantile.tms.get("WebMercatorQuad")

%timeit -n 10 -r 10 tms.bbox
877 ns ± 5.73 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```