### PR TITLE
update model to match TMS2.0 and add descriptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,41 @@
 ## 4.0.0 (TBD)
 
 * Remove assumption tile rows/cols are ordered in `TileMatrixSet.tiles()` method (author @fsvenson, https://github.com/developmentseed/morecantile/pull/104)
-* switch to **TMS 2.0** specification (author @dchirst, https://github.com/developmentseed/morecantile/pull/101)
+* switch to **TMS 2.0** specification (author @dchirst, https://github.com/developmentseed/morecantile/pull/101). See https://developmentseed.org/morecantile/tms-v2/ for more info.
 * remove `NZTM2000` TileMatrixSet (ref: https://github.com/developmentseed/morecantile/issues/103)
 * add `rasterio_geographic_crs` to export TMS's geographic CRS to Rasterio's CRS object (author @AndrewAnnex, https://github.com/developmentseed/morecantile/pull/109)
 * add `geographic_crs` property in the TileMatrixSet model to return the private `_geographic_crs` attribute
 * add cache LRU layer on top of `TileMatrixSet.bbox` method
+* changed the input type in `morecantile.defaults.TileMatrixSets.register()` from `Sequence[TileMatrixSet]` to `Dict[str, TileMatrixSets]`
+
+    ```python
+    my_custom_tms = ...
+
+    # before
+    defaults = morecantile.tms.register([my_custom_tms])
+
+    # now
+    defaults = morecantile.tms.register({"MyCustomGrid": my_custom_tms})
+    ```
+
+* made `id` and `title` optional in `morecantile.TileMatrixSet.custom()` method
+
+    ```python
+    crs = CRS.from_epsg(3031)
+    extent = [-948.75, -543592.47, 5817.41, -3333128.95]  # From https:///epsg.io/3031
+
+    # before
+    tms = morecantile.TileMatrixSet.custom(extent, crs)
+    print(tms.id, tms.title)
+    >>> "Custom", "Custom TileMatrixSet"
+
+    # now
+    tms = morecantile.TileMatrixSet.custom(extent, crs)
+    print(tms.id, tms.title)
+    >>> None, None
+    ```
+
+* remove `boundingBox` in TileMatrixSet definition when created with `morecantile.TileMatrixSet.custom`
 
 ## 3.3.0 (2023-03-09)
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,50 @@ $ python -m pip install -U pip
 $ python -m pip install morecantile
 
 # Or install from source:
-
 $ python -m pip install -U pip
 $ python -m pip install git+https://github.com/developmentseed/morecantile.git
 ```
 
+## Usage
+
+```python
+import morecantile
+
+tms = morecantile.tms.get("WebMercatorQuad")
+
+# Get TMS bounding box
+print(tms.xy_bbox)
+>>> BoundingBox(
+    left=-20037508.342789244,
+    bottom=-20037508.34278919,
+    right=20037508.34278919,
+    top=20037508.342789244,
+)
+
+# Get the bounds for tile Z=4, X=10, Y=10 in the TMS's CRS (e.g epsg:3857)
+print(tms.xy_bounds(morecantile.Tile(10, 10, 4)))
+>>> BoundingBox(
+    left=5009377.085697308,
+    bottom=-7514065.628545959,
+    right=7514065.628545959,
+    top=-5009377.085697308,
+)
+
+# Get the bounds for tile Z=4, X=10, Y=10 in Geographic CRS (e.g epsg:4326)
+print(tms.bounds(morecantile.Tile(10, 10, 4)))
+>>> BoundingBox(
+    left=44.999999999999964,
+    bottom=-55.776573018667634,
+    right=67.4999999999999,
+    top=-40.97989806962009,
+)
+```
+
+More info can be found at https://developmentseed.org/morecantile/usage/
+
 ### Defaults Grids
+
+`morecantile` provides a set of default TMS grids:
 
 - **CanadianNAD83_LCC**: Lambert conformal conic NAD83 for Canada - EPSG:3978
 - **EuropeanETRS89_LAEAQuad**: ETRS89-extended / LAEA Europe - EPGS:3035

--- a/docs/src/tms-v2.md
+++ b/docs/src/tms-v2.md
@@ -5,11 +5,12 @@ In September 2022, the Open Geospatial Consortium released an updated specificat
 This updated spec includes some breaking changes that alter the TMS JSON document. Some of these changes include:
 
 - [Addition of a `uri` parameter for TileMatrixSets registered on the official OGC NA TileMatrixSets registry](https://docs.ogc.org/is/17-083r4/21-066r1.html#_identifying_with_uri_a_well_known_tilematrixset_in_an_authoritative_registry)
-- [`identifier` renamed to `id`](https://docs.ogc.org/is/17-083r4/21-066r1.html#_json_encoding_rules_to_derive_a_more_natural_json_encoding_from_uml)
+- [`identifier` renamed to `id`](https://docs.ogc.org/is/17-083r4/21-066r1.html#_json_encoding_rules_to_derive_a_more_natural_json_encoding_from_uml) in both TileMatrix and TileMatrixSet
+- [Only `crs` and `tileMatrices` are required in `TileMatrixSet`](https://github.com/opengeospatial/2D-Tile-Matrix-Set/blob/master/schemas/tms/2.0/json/tileMatrixSet.json#L6)
 - [`supportedCRS` renamed to `crs`](https://docs.ogc.org/is/17-083r4/21-066r1.html#_renaming_supportedcrs_to_crs)
 - [`tileMatrix` renamed to `tileMatrices`](https://docs.ogc.org/is/17-083r4/21-066r1.html#_json_encoding_rules_to_derive_a_more_natural_json_encoding_from_uml)
 - [`topLeftCorner` renamed to `pointOfOrigin`](https://docs.ogc.org/is/17-083r4/21-066r1.html#_replacing_topleftcorner_by_pointoforigin)
-- [Add optional parameters `cellSize` and `cornerOfOrigin` to TileMatrix](https://docs.ogc.org/is/17-083r4/21-066r1.html#_adding_cellsize_and_corneroforigin)
+- [Add `cellSize` and `cornerOfOrigin` (Optional) parameters to TileMatrix](https://docs.ogc.org/is/17-083r4/21-066r1.html#_adding_cellsize_and_corneroforigin)
 - [Remove `type` object properties](https://docs.ogc.org/is/17-083r4/21-066r1.html#_removing_type_object_properties)
 - [Added optional axis ordering](https://docs.ogc.org/is/17-083r4/21-066r1.html#_adding_optional_orderedaxes_to_highlight_crs_axis_ordering
 )

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -1,25 +1,5 @@
-### List supported grids
 
-```python
-import morecantile
-
-print(morecantile.tms.list())
->>> [
-    'LINZAntarticaMapTilegrid',
-    'EuropeanETRS89_LAEAQuad',
-    'CanadianNAD83_LCC',
-    'UPSArcticWGS84Quad',
-    'NZTM2000Quad',
-    'UTM31WGS84Quad',
-    'UPSAntarcticWGS84Quad',
-    'WorldMercatorWGS84Quad',
-    'WorldCRS84Quad',
-    'WGS1984Quad',
-    'WebMercatorQuad'
-]
-```
-
-### Load one of the default grids
+### Load one TMS grid
 ```python
 import morecantile
 
@@ -150,35 +130,51 @@ print(customEPGS3031.matrix(0).dict(exclude_none=True))
 }
 ```
 
-And register the TMS
+## Use morecantile TMS store
+
+morecantile provides a `TileMatrixSets` class to *store* Tile Matrix Set definition. This object can easily be extended to include your own custom TMS.
+
+### List supported grids
+
 ```python
-default_tms = morecantile.tms.register(customEPGS3031)
+import morecantile
+
+print(morecantile.tms.list())
+>>> [
+    'LINZAntarticaMapTilegrid',
+    'EuropeanETRS89_LAEAQuad',
+    'CanadianNAD83_LCC',
+    'UPSArcticWGS84Quad',
+    'NZTM2000Quad',
+    'UTM31WGS84Quad',
+    'UPSAntarcticWGS84Quad',
+    'WorldMercatorWGS84Quad',
+    'WorldCRS84Quad',
+    'WGS1984Quad',
+    'WebMercatorQuad'
+]
+```
+
+### Register a custom TMS
+
+```python
+default_tms = morecantile.tms.register({"MyCustomTmsEPSG3031": customEPGS3031})
+assert "MyCustomTmsEPSG3031" in default_tms.list()
+
 tms = default_tms.get("MyCustomTmsEPSG3031")
 tms
 >>> <TileMatrixSet title='Custom TileMatrixSet' id='MyCustomTmsEPSG3031'>
 ```
 
-!!! important
-    starting with `morecantile==1.3.0`, you can create TMS using custom CRS.
+### Automatically register TMS documents
 
-    ```python
-    import morecantile
-    from pyproj import CRS
-
-    crs = CRS.from_proj4("+proj=stere +lat_0=90 +lon_0=0 +k=2 +x_0=0 +y_0=0 +R=3396190 +units=m +no_defs")
-    extent = [-13584760.000,-13585240.000,13585240.000,13584760.000]
-    tms = morecantile.TileMatrixSet.custom(extent, crs, id="MarsNPolek2MOLA5k")
-    ```
-
-### Extend morecantile default TMS
-
-Since the release of morecantile `1.3.1`, users can automatically extend morecantile default TMS with their custom TMS JSON files stored in a directory by setting `TILEMATRIXSET_DIRECTORY` environment.
+Since the release of morecantile `1.3.1`, users can automatically extend morecantile's default TMS with their custom TMS JSON files stored in a directory, by setting `TILEMATRIXSET_DIRECTORY` environment.
 
 !!! important
     Morecantile will look for all `.json` files within the directory referenced by `TILEMATRIXSET_DIRECTORY`.
 
-    - Filename HAVE TO be the same as the TMS identifer
-    - Filename HAVE TO be *without special characters* `[a-zA-Z0-9_]`
+    - filename HAVE TO be the same as the TMS id
+    - filename HAVE TO be *without special characters* `[a-zA-Z0-9_]`
 
 ## Morecantile + Pydantic
 
@@ -197,4 +193,10 @@ import morecantile
 my_tms_doc = "~/a_tms_doc.json"
 
 tms = morecantile.TileMatrixSet.parse_file(my_tms_doc)
+
+# print the TMS as json
+print(tms.json(exclude_none=True))
+
+# print the TMS as dict
+print(tms.dict(exclude_none=True))
 ```

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -31,27 +31,21 @@ def test_register():
     extent = [-948.75, -543592.47, 5817.41, -3333128.95]  # From https:///epsg.io/3031
     tms = morecantile.TileMatrixSet.custom(extent, crs, id="MyCustomGrid3031")
 
-    _ = morecantile.tms.register(tms)
+    # Make sure we don't update the default tms (frozen set)
+    _ = morecantile.tms.register({"MyCustomGrid3031": tms})
     assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT
 
-    defaults = morecantile.tms.register(tms)
-    assert len(defaults.list()) == DEFAULT_GRID_COUNT + 1
-    assert "MyCustomGrid3031" in defaults.list()
-
-    defaults = morecantile.tms.register([tms])
+    defaults = morecantile.tms.register({"MyCustomGrid3031": tms})
     assert len(defaults.list()) == DEFAULT_GRID_COUNT + 1
     assert "MyCustomGrid3031" in defaults.list()
 
     # Check it will raise an exception if TMS is already registered
     with pytest.raises(Exception):
-        defaults = defaults.register(tms)
+        defaults = defaults.register({"MyCustomGrid3031": tms})
 
     # Do not raise is overwrite=True
-    defaults = defaults.register(tms, overwrite=True)
+    defaults = defaults.register({"MyCustomGrid3031": tms}, overwrite=True)
     assert len(defaults.list()) == DEFAULT_GRID_COUNT + 1
-
-    # make sure the default morecantile TMS are not overwriten
-    assert len(morecantile.defaults.default_tms.keys()) == DEFAULT_GRID_COUNT
 
     # add tms in morecantile defaults (not something to do anyway)
     epsg3031 = morecantile.TileMatrixSet.custom(extent, crs, id="epsg3031")


### PR DESCRIPTION
This PR update the model to better match the TMS2.0 specification JSON model found in https://github.com/opengeospatial/2D-Tile-Matrix-Set/blob/master/schemas/tms/2.0/json/tileMatrix.json and https://github.com/opengeospatial/2D-Tile-Matrix-Set/blob/master/schemas/tms/2.0/json/tileMatrixSet.json

### TL%DR
- remove `type` 
- add `cellSize` as required field in TileMatrix
- update `tileWidth/tileHeight`  and `matrixWidth/matrixHeight` requirements
- make tile matrix set `id` an **Optional** parameter **BREAKING**
- fix `cornerOfOrigin` type

### Optional `id` 

only `crs` and `tileMatrices` are required in the TileMatrixSet specification (https://github.com/opengeospatial/2D-Tile-Matrix-Set/blob/master/schemas/tms/2.0/json/tileMatrixSet.json#L6) but we use it in the TMS Datastore in https://github.com/developmentseed/morecantile/blob/main/morecantile/defaults.py#L56-L61 which is now incompatible. 

I'll change the TMS class in another PR to change the input from `Sequence[TileMatrixSet]` to `Dict[str, TileMatrixSet]`

cc @dchirst 