### PR TITLE
Raise a ValueError when nan bounds are passed to tiles

### DIFF
--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -867,6 +867,9 @@ class TileMatrixSet(BaseModel):
         function yields exactly one tile when given the bounds of that same tile.
 
         """
+        if any(math.isnan(coord) for coord in (west, south, east, north)):
+            raise ValueError("All coordinates must be finite")
+
         if isinstance(zooms, int):
             zooms = (zooms,)
 

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -1,5 +1,7 @@
 """Tests for morecantile."""
 
+import math
+
 import mercantile
 import pytest
 from pyproj import CRS
@@ -437,6 +439,18 @@ def test_tiles_roundtrip(t):
     assert val.x == t.x
     assert val.y == t.y
     assert val.z == t.z
+
+
+def test_tiles_nan_bounds():
+    """
+    nan bounds should raise an error instead of getting clamped to avoid
+    unintentionally generating tiles for the entire TMS' extent.
+    """
+    tms = morecantile.tms.get("WebMercatorQuad")
+
+    bounds = (-105, math.nan, -104.99, 40)
+    with pytest.raises(ValueError):
+        list(tms.tiles(*bounds, zooms=[14]))
 
 
 def test_extend_zoom():


### PR DESCRIPTION
Otherwise the coordinate could get unintentionally clamped to the TMS' extremeties: https://github.com/developmentseed/morecantile/blob/248cbc56d306d047e7ec1aaf559b3928e9c18c37/morecantile/models.py#L885-L889

```python
>>> from math import nan
>>> max(nan, -180)
nan
>>> min(nan, 180)
nan
>>> max(-180, nan)
-180
>>> min(180, nan)
180
```
