### PR TITLE
Update CRS model and add _crs private attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 ## 4.1.0 (2023-06-06)
 
-* Change CRS models to align more with the TMS spec and fix some OpenAPI schema issues
-* add `TileMatrixSet._crs` PrivateAttr to host the `pyproj.CRS` (created from CRS uri/wkt)
-* update `grid_crs` properties in `TileMatrixSet.feature()` result to return the `CRS` (uri/wkt) instead of EPSG code
+* Change CRS attribute in model to align more with the TMS spec and fix some OpenAPI schema issues (It should be a string URI or WKT, not a pyproj.CRS)
+* add `TileMatrixSet._crs` PrivateAttr to host the `pyproj.CRS` version of the crs
+* update `grid_crs` properties in `TileMatrixSet.feature()` result to return the `TileMatrixSet.CRS` (uri/wkt) instead of EPSG code
 
 ## 4.0.2 (2023-05-31)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 4.1.0 (2023-06-06)
+
+* Change CRS models to align more with the TMS spec and fix some OpenAPI schema issues
+* add `TileMatrixSet._crs` PrivateAttr to host the `pyproj.CRS` (created from CRS uri/wkt)
+* update `grid_crs` properties in `TileMatrixSet.feature()` result to return the `CRS` (uri/wkt) instead of EPSG code
 
 ## 4.0.2 (2023-05-31)
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -156,7 +156,6 @@ class TMSBoundingBox(BaseModel):
         """Configure TMSBoundingBox."""
 
         arbitrary_types_allowed = True
-        # json_encoders = {CRS: lambda v: CRS_to_uri(v)}
 
 
 # class variableMatrixWidth(BaseModel):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ def test_cli_shapes():
     assert result.exit_code == 0
     assert (
         result.output
-        == '{"bbox": [-105.46875, 39.909736, -104.765625, 40.446947], "geometry": {"coordinates": [[[-105.46875, 39.909736], [-105.46875, 40.446947], [-104.765625, 40.446947], [-104.765625, 39.909736], [-105.46875, 39.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "EPSG:3857", "grid_name": "WebMercatorQuad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
+        == '{"bbox": [-105.46875, 39.909736, -104.765625, 40.446947], "geometry": {"coordinates": [[[-105.46875, 39.909736], [-105.46875, 40.446947], [-104.765625, 40.446947], [-104.765625, 39.909736], [-105.46875, 39.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "http://www.opengis.net/def/crs/EPSG/0/3857", "grid_name": "WebMercatorQuad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
     )
 
     # tile as arg
@@ -24,7 +24,7 @@ def test_cli_shapes():
     assert result.exit_code == 0
     assert (
         result.output
-        == '{"bbox": [-105.46875, 39.909736, -104.765625, 40.446947], "geometry": {"coordinates": [[[-105.46875, 39.909736], [-105.46875, 40.446947], [-104.765625, 40.446947], [-104.765625, 39.909736], [-105.46875, 39.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "EPSG:3857", "grid_name": "WebMercatorQuad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
+        == '{"bbox": [-105.46875, 39.909736, -104.765625, 40.446947], "geometry": {"coordinates": [[[-105.46875, 39.909736], [-105.46875, 40.446947], [-104.765625, 40.446947], [-104.765625, 39.909736], [-105.46875, 39.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "http://www.opengis.net/def/crs/EPSG/0/3857", "grid_name": "WebMercatorQuad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
     )
 
     # buffer
@@ -34,7 +34,7 @@ def test_cli_shapes():
     assert result.exit_code == 0
     assert (
         result.output
-        == '{"bbox": [-106.46875, 38.909736, -103.765625, 41.446947], "geometry": {"coordinates": [[[-106.46875, 38.909736], [-106.46875, 41.446947], [-103.765625, 41.446947], [-103.765625, 38.909736], [-106.46875, 38.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "EPSG:3857", "grid_name": "WebMercatorQuad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
+        == '{"bbox": [-106.46875, 38.909736, -103.765625, 41.446947], "geometry": {"coordinates": [[[-106.46875, 38.909736], [-106.46875, 41.446947], [-103.765625, 41.446947], [-103.765625, 38.909736], [-106.46875, 38.909736]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "http://www.opengis.net/def/crs/EPSG/0/3857", "grid_name": "WebMercatorQuad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
     )
 
     # Output is compact
@@ -102,7 +102,7 @@ def test_cli_shapesWGS84():
     assert result.exit_code == 0
     assert (
         result.output
-        == '{"bbox": [-105.46875, 40.099155, -104.765625, 40.636956], "geometry": {"coordinates": [[[-105.46875, 40.099155], [-105.46875, 40.636956], [-104.765625, 40.636956], [-104.765625, 40.099155], [-105.46875, 40.099155]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "EPSG:3395", "grid_name": "WorldMercatorWGS84Quad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
+        == '{"bbox": [-105.46875, 40.099155, -104.765625, 40.636956], "geometry": {"coordinates": [[[-105.46875, 40.099155], [-105.46875, 40.636956], [-104.765625, 40.636956], [-104.765625, 40.099155], [-105.46875, 40.099155]]], "type": "Polygon"}, "id": "(106, 193, 9)", "properties": {"grid_crs": "http://www.opengis.net/def/crs/EPSG/0/3395", "grid_name": "WorldMercatorWGS84Quad", "title": "XYZ tile (106, 193, 9)"}, "type": "Feature"}\n'
     )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,8 @@ def test_tile_matrix_set(tileset):
     # Confirm model validation is working
     ts = TileMatrixSet.parse_file(tileset)
     # This would fail if `crs` isn't supported by PROJ
-    isinstance(ts.crs, CRS)
+    assert isinstance(ts._crs, CRS)
+    assert ts._crs == ts.crs.__root__
 
 
 def test_tile_matrix_iter():
@@ -356,6 +357,8 @@ def test_mars_local_tms():
         title="Web Mercator Mars",
         geographic_crs=MARS2000_SPHERE,
     )
+    assert syrtis_tms._crs == syrtis_tms.crs.__root__
+
     center = syrtis_tms.ul(1, 1, 1)
     assert round(center.x, 6) == 76.5
     assert round(center.y, 6) == 17
@@ -382,7 +385,7 @@ def test_from_v1(identifier, file, crs):
 
     tms = TileMatrixSet.from_v1(v1_tms)
     assert tms.id == identifier
-    assert tms.crs == pyproj.CRS.from_epsg(crs)
+    assert tms._crs == pyproj.CRS.from_epsg(crs)
 
 
 @pytest.mark.parametrize(
@@ -429,7 +432,7 @@ def test_crs_uris(authority, code, result):
 def test_crs_uris_for_defaults(tilematrixset):
     """Test CRS URIS."""
     t = morecantile.tms.get(tilematrixset)
-    assert t.crs == morecantile.models.CRS_to_uri(t.crs)
+    assert t._crs == morecantile.models.CRS_to_uri(t._crs)
 
 
 def test_rasterio_crs():

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -68,8 +68,8 @@ def test_register():
 def test_TMSproperties():
     """Test TileSchema()."""
     tms = morecantile.tms.get("WebMercatorQuad")
-    assert tms.crs == CRS.from_epsg(3857)
-    assert meters_per_unit(tms.crs) == 1.0
+    assert tms._crs == CRS.from_epsg(3857)
+    assert meters_per_unit(tms._crs) == 1.0
     assert tms.minzoom == 0
     assert tms.maxzoom == 24
 
@@ -297,7 +297,7 @@ def test_axis_inverted(tms_name):
     tms = morecantile.tms.get(tms_name)
     if tms.orderedAxes:
         assert morecantile.models.crs_axis_inverted(
-            tms.crs
+            tms._crs
         ) == morecantile.models.ordered_axis_inverted(tms.orderedAxes)
 
 


### PR DESCRIPTION
This PR does:
- replace `CRSType` model to better match the TMS spec
- keep CRSType as URI/WKT instead of parsing it to pyproj.CRS
- add `TileMatrixSet._crs` to host the pyproj.CRS version of the TMS crs

IMO While this change the API slightly I don't think this should result a Major version.