### PR TITLE
proxy to_epsg and to_wkt methods to CRSType

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+## 4.1.1 (2023-06-07)
+
+* add `to_epsg()` and `to_wkt()` methods to `CRSType` to allow compatibility with `4.0`
+
+```python
+import morecantile
+
+tms = morecantile.tms.get("WebMercatorQuad")
+
+tms.crs
+>> CRSType(__root__='http://www.opengis.net/def/crs/EPSG/0/3857')
+
+tms.crs.to_epsg()
+>> 3857
+
+tms._crs
+>> <Projected CRS: EPSG:3857>
+
+tms._crs.to_epsg()
+>> 3857
+```
+
 ## 4.1.0 (2023-06-06)
 
 * Change CRS attribute in model to align more with the TMS spec and fix some OpenAPI schema issues (It should be a string URI or WKT, not a pyproj.CRS)

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -110,6 +110,16 @@ class CRSType(BaseModel):
         assert CRS.from_user_input(values.get("__root__"))
         return values
 
+    def to_epsg(self) -> Optional[int]:
+        """return EPSG number of the CRS."""
+        crs = CRS.from_user_input(self.__root__)
+        return crs.to_epsg()
+
+    def to_wkt(self) -> str:
+        """return WKT version of the CRS."""
+        crs = CRS.from_user_input(self.__root__)
+        return crs.to_wkt()
+
 
 def CRS_to_uri(crs: CRS) -> str:
     """Convert CRS to URI."""

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -24,7 +24,6 @@ from pydantic import (
     Field,
     PrivateAttr,
     conlist,
-    root_validator,
     validator,
 )
 from pyproj import CRS, Transformer
@@ -103,22 +102,23 @@ class CRSType(BaseModel):
     """
 
     __root__: Union[str, Union[CRSUri, CRSWKT]] = Field(..., title="CRS")
+    _pyproj_crs: CRS = PrivateAttr()
 
-    @root_validator
-    def validate_crs(cls, values):
-        """Make sure the CRS can be used in Pyproj."""
-        assert CRS.from_user_input(values.get("__root__"))
-        return values
+    def __init__(self, **data):
+        """Custom Init to validate CRS string and create Pyproj CRS object."""
+        super().__init__(**data)
+
+        _pyproj_crs = CRS.from_user_input(data.get("__root__"))
+
+        self._pyproj_crs = _pyproj_crs
 
     def to_epsg(self) -> Optional[int]:
         """return EPSG number of the CRS."""
-        crs = CRS.from_user_input(self.__root__)
-        return crs.to_epsg()
+        return self._pyproj_crs.to_epsg()
 
     def to_wkt(self) -> str:
         """return WKT version of the CRS."""
-        crs = CRS.from_user_input(self.__root__)
-        return crs.to_wkt()
+        return self._pyproj_crs.to_wkt()
 
 
 def CRS_to_uri(crs: CRS) -> str:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -386,6 +386,8 @@ def test_from_v1(identifier, file, crs):
     tms = TileMatrixSet.from_v1(v1_tms)
     assert tms.id == identifier
     assert tms._crs == pyproj.CRS.from_epsg(crs)
+    assert tms.crs.to_epsg() == tms._crs.to_epsg()
+    assert tms.crs.to_wkt() == tms._crs.to_wkt()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds `to_epsg` and `to_wkt` methods to CRSType for compatibility with `4.0`

ref https://github.com/developmentseed/morecantile/pull/123#issuecomment-1580458607

cc @roelarents