### PR TITLE
remove TileMatrixSet _crs private attribute to rely on CRSType _pyproj_crs property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 4.2.0 (2023-06-09)
+
+* add `to_proj4` and `to_dict` and `to_json` methods to `CRSType`
+* remove `TileMatrixSet._crs` (replaced with `TileMatrixSet.crs._pyproj_crs`)
+
 ## 4.1.1 (2023-06-07)
 
 * add `to_epsg()` and `to_wkt()` methods to `CRSType` to allow compatibility with `4.0`

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,8 +29,8 @@ def test_tile_matrix_set(tileset):
     # Confirm model validation is working
     ts = TileMatrixSet.parse_file(tileset)
     # This would fail if `crs` isn't supported by PROJ
-    assert isinstance(ts._crs, CRS)
-    assert ts._crs == ts.crs.__root__
+    assert isinstance(ts.crs._pyproj_crs, CRS)
+    assert ts.crs._pyproj_crs == ts.crs.__root__
 
 
 def test_tile_matrix_iter():
@@ -357,7 +357,7 @@ def test_mars_local_tms():
         title="Web Mercator Mars",
         geographic_crs=MARS2000_SPHERE,
     )
-    assert syrtis_tms._crs == syrtis_tms.crs.__root__
+    assert SYRTIS_TM == syrtis_tms.crs._pyproj_crs
 
     center = syrtis_tms.ul(1, 1, 1)
     assert round(center.x, 6) == 76.5
@@ -385,9 +385,7 @@ def test_from_v1(identifier, file, crs):
 
     tms = TileMatrixSet.from_v1(v1_tms)
     assert tms.id == identifier
-    assert tms._crs == pyproj.CRS.from_epsg(crs)
-    assert tms.crs.to_epsg() == tms._crs.to_epsg()
-    assert tms.crs.to_wkt() == tms._crs.to_wkt()
+    assert tms.crs._pyproj_crs == pyproj.CRS.from_epsg(crs)
 
 
 @pytest.mark.parametrize(
@@ -434,7 +432,7 @@ def test_crs_uris(authority, code, result):
 def test_crs_uris_for_defaults(tilematrixset):
     """Test CRS URIS."""
     t = morecantile.tms.get(tilematrixset)
-    assert t._crs == morecantile.models.CRS_to_uri(t._crs)
+    assert t.crs._pyproj_crs == morecantile.models.CRS_to_uri(t.crs._pyproj_crs)
 
 
 def test_rasterio_crs():

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -68,8 +68,8 @@ def test_register():
 def test_TMSproperties():
     """Test TileSchema()."""
     tms = morecantile.tms.get("WebMercatorQuad")
-    assert tms._crs == CRS.from_epsg(3857)
-    assert meters_per_unit(tms._crs) == 1.0
+    assert tms.crs._pyproj_crs == CRS.from_epsg(3857)
+    assert meters_per_unit(tms.crs._pyproj_crs) == 1.0
     assert tms.minzoom == 0
     assert tms.maxzoom == 24
 
@@ -297,7 +297,7 @@ def test_axis_inverted(tms_name):
     tms = morecantile.tms.get(tms_name)
     if tms.orderedAxes:
         assert morecantile.models.crs_axis_inverted(
-            tms._crs
+            tms.crs._pyproj_crs
         ) == morecantile.models.ordered_axis_inverted(tms.orderedAxes)
 
 


### PR DESCRIPTION
This PR does:
- remove the useless `_crs` private attribute (because it's already stored in `CRSType._pyproj_crs`)
- add more `to_*` methods to CRSType

I'm only changing a `private` attribute so I'm again not making a Major release for this change 🙈 

@roelarents I'll wait for your 👍 👎 🙏 