### PR TITLE
allow specifying a custom rendering pixel size

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -105,6 +105,8 @@ Here are the available options:
 
 - **geographic_crs** (*pyproj.CRS, defaults to `EPSG:4326`*): Geographic (lat,lon) coordinate reference system
 
+- **rendering_pixel_size** (*float, defaults to `0.00028`*): Size in meters of an on-screen pixel
+
 
 ```python
 import morecantile

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -554,3 +554,20 @@ def test_crs_type():
     assert crs._pyproj_crs == CRS.from_epsg(3857)
     assert crs.srs == wkt
     assert crs.to_epsg() == 3857
+
+
+@pytest.mark.parametrize(
+    ("rendering_pixel_size", "expected_scale_denominator"),
+    [
+        (0.00028, 279700977.9575893),
+        (0.000264, 296652552.3792614),
+    ],
+)
+def test_rendering_pixel_size(rendering_pixel_size, expected_scale_denominator):
+    """Check rendering pixel size is used to compute scaleDenominator"""
+    crs = CRS.from_epsg(3857)
+    extent = [-20026376.39, -20048966.10, 20026376.39, 20048966.10]
+    tms = morecantile.TileMatrixSet.custom(
+        extent, crs, id="MyCustomTmsEPSG3857", rendering_pixel_size=rendering_pixel_size
+    )
+    assert tms.matrix(1).scaleDenominator == expected_scale_denominator


### PR DESCRIPTION
Hi :wave:

We've been using morecantile successfully for a while now and we started using it to connect to [ArcGIS Online services](https://developers.arcgis.com/rest/services-reference/enterprise/image-service.htm), which generates custom tiling schemes.

Doing so, we noticed ArcGIS servers give a [`tileInfo.dpi`](https://developers.arcgis.com/net/api-reference/api/netwin/Esri.ArcGISRuntime/Esri.ArcGISRuntime.ArcGISServices.TileInfo.html) value (with a value of 96 in this case). Converting this to mm gives 0.264mm, which we figured we should use instead of 0.28mm as the rendering pixel size. Since this number is used to compute `scaleDenominator`, `resolution` and finally tile coordinates, our reasoning was that getting this number right mattered. So we forked morecantile to extend it to support a custom `rendering_pixel_size` parameter.

The OGC specs do mention this 96 DPI vs 0.28mm as a [potential source of confusion](https://docs.ogc.org/is/17-083r2/17-083r2.html#9), and digging further into how tile coordinates are computed in morecantile, it seems like `rendering_pixel_size` cancels itself out in the math?
- `scaleDenominator` is computed as `scaleDenominator = resolution * meters_per_unit / rendering_pixel_size`, where `resolution` is defined as (`bbox_width_meters / tile_width / 2**zoom_level`)
- To generate tile coordinates, `resolution` is later recomputed from the `scaleDenominator` as `resolution = scaleDenominator * rendering_pixel_size / meters_per_unit`.
- This simplifies to the original `resolution = bbox_width_meters / tile_width / 2**zoom_level`, where the rendering pixel size doesn't appear anymore.

I'm probably misunderstanding some important bits, but:
- Is my understanding correct that changing `rendering_pixel_size` to some value other than 0.28 does not impact the tile coordinates computations?
- Would it have other (positive or negative) side-effects?
- Is this ArcGIS DPI value safe to ignore? We'll have to ask the folks at ESRI, but I wondered if you had an idea what other purpose this value could have (some purely rendering concerns?)

Disclaimer: this is out of my comfort zone, happy to learn more!