### PR TITLE
better CRS parsing and fix TileMatrixSet model

### DIFF
--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -113,7 +113,7 @@ class CRS(RootModel[Union[str, Union[CRSUri, CRSWKT, CRSRef]]]):
 
         elif isinstance(self.root, CRSRef):
             raise NotImplementedError(
-                "Morecantile do not support `MD_ReferenceSystem` defined CRS"
+                "Morecantile does not support `MD_ReferenceSystem` defined CRS"
             )
 
     @property


### PR DESCRIPTION
This PR fixes couples bugs with the CRS and TileMatrixSet models 

- rename `CRSType` -> `CRS` (and internally use `pyproj.CRS` for pyproj's CRS object)
- enable passing `{"uri": ...}` or `{"wkt": ...}` to define the CRS (per specification) 
- use pyproj.CRS's URI representation with `TileMatrixSet`'s `repr`
- remove `pointOfOrigin` default value (it's required)
- add `"topLeft"` default for `cornerOfOrigin` 