### PR TITLE
Custom TMS with decimation

### DIFF
--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -716,7 +716,7 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
             transform = pyproj.Transformer.from_crs(extent_crs, crs, always_xy=True)
             extent = transform.transform_bounds(*extent, densify_pts=21)
 
-        if decimation_base < 2:
+        if decimation_base <= 1:
             raise ValueError(
                 "Custom TileMatrixSet requires a decimation base that is greater than 1."
             )

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -696,7 +696,7 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         screen_pixel_size: float, optional
             Rendering pixel size. 0.28 mm was the actual pixel size of a common display from 2005 and considered as standard by OGC.
         decimation: int, optional
-            How tiles are divided at each zoom level (default is 2).
+            How tiles are divided at each zoom level (default is 2). Must be greater than 1.
         kwargs: Any
             Attributes to forward to the TileMatrixSet
 
@@ -715,6 +715,11 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         if extent_crs:
             transform = pyproj.Transformer.from_crs(extent_crs, crs, always_xy=True)
             extent = transform.transform_bounds(*extent, densify_pts=21)
+
+        if decimation < 2:
+            raise ValueError(
+                "Custom TileMatrixSet require a decimation that is greater than 1."
+            )
 
         bbox = BoundingBox(*extent)
         x_origin = bbox.left if not is_inverted else bbox.top

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -660,6 +660,7 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         ordered_axes: Optional[List[str]] = None,
         geographic_crs: pyproj.CRS = WGS84_CRS,
         screen_pixel_size: float = 0.28e-3,
+        decimation: int = 2,
         **kwargs: Any,
     ):
         """
@@ -694,6 +695,8 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
             Geographic (lat,lon) coordinate reference system (default is EPSG:4326)
         screen_pixel_size: float, optional
             Rendering pixel size. 0.28 mm was the actual pixel size of a common display from 2005 and considered as standard by OGC.
+        decimation: int, optional
+            How tiles are divided at each zoom level (default is 2).
         kwargs: Any
             Attributes to forward to the TileMatrixSet
 
@@ -723,8 +726,8 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         tile_matrices: List[TileMatrix] = []
         for zoom in range(minzoom, maxzoom + 1):
             res = max(
-                width / (tile_width * matrix_scale[0]) / 2.0**zoom,
-                height / (tile_height * matrix_scale[1]) / 2.0**zoom,
+                width / (tile_width * matrix_scale[0]) / float(decimation) ** zoom,
+                height / (tile_height * matrix_scale[1]) / float(decimation) ** zoom,
             )
             tile_matrices.append(
                 TileMatrix(
@@ -735,8 +738,8 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
                         "pointOfOrigin": [x_origin, y_origin],
                         "tileWidth": tile_width,
                         "tileHeight": tile_height,
-                        "matrixWidth": matrix_scale[0] * 2**zoom,
-                        "matrixHeight": matrix_scale[1] * 2**zoom,
+                        "matrixWidth": matrix_scale[0] * decimation**zoom,
+                        "matrixHeight": matrix_scale[1] * decimation**zoom,
                     }
                 )
             )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -185,6 +185,25 @@ def test_custom_tms_bounds_user_crs():
     assert custom_tms.bounds(0, 0, 0) == (-120, 30, -110, 40)
 
 
+def test_custom_tms_decimation():
+    """Check bounds with epsg6342 and custom decimation."""
+    decimation = 3
+    extent = (238170, 4334121, 377264, 4473215)
+    left, bottom, right, top = extent
+    custom_tms = TileMatrixSet.custom(
+        extent,
+        pyproj.CRS.from_epsg(6342),
+        decimation=decimation,
+    )
+    for z in [0, 1, 2, 3]:
+        tile_width = (right - left) / decimation**z
+        tile_height = (top - bottom) / decimation**z
+        expected = (left, top - tile_height, left + tile_width, top)
+        tile_bounds = custom_tms.xy_bounds(0, 0, z)
+        for a, b in zip(expected, tile_bounds):
+            assert round(a - b, 4) == 0
+
+
 def test_nztm_quad_is_quad():
     """Test NZTM2000Quad."""
     tms = morecantile.tms.get("NZTM2000Quad")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -195,6 +195,12 @@ def test_custom_tms_decimation():
             pyproj.CRS.from_epsg(6342),
             decimation_base=decimation_base,
         )
+
+        if decimation_base == 2:
+            assert custom_tms.is_quadtree
+        else:
+            assert not custom_tms.is_quadtree
+
         for zoom in [0, 1, 2, 3]:
             tile_width = (right - left) / decimation_base**zoom
             tile_height = (top - bottom) / decimation_base**zoom

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -186,18 +186,18 @@ def test_custom_tms_bounds_user_crs():
 
 
 def test_custom_tms_decimation():
-    """Check bounds with epsg6342 and custom decimation."""
+    """Check bounds with epsg6342 and custom decimation base."""
     extent = (238170, 4334121, 377264, 4473215)
     left, bottom, right, top = extent
-    for decimation in [2, 3, 4, 5]:
+    for decimation_base in [2, 3, 4, 5]:
         custom_tms = TileMatrixSet.custom(
             extent,
             pyproj.CRS.from_epsg(6342),
-            decimation=decimation,
+            decimation_base=decimation_base,
         )
         for zoom in [0, 1, 2, 3]:
-            tile_width = (right - left) / decimation**zoom
-            tile_height = (top - bottom) / decimation**zoom
+            tile_width = (right - left) / decimation_base**zoom
+            tile_height = (top - bottom) / decimation_base**zoom
             expected = (left, top - tile_height, left + tile_width, top)
             tile_bounds = custom_tms.xy_bounds(0, 0, zoom)
             for a, b in zip(expected, tile_bounds):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -187,21 +187,21 @@ def test_custom_tms_bounds_user_crs():
 
 def test_custom_tms_decimation():
     """Check bounds with epsg6342 and custom decimation."""
-    decimation = 3
     extent = (238170, 4334121, 377264, 4473215)
     left, bottom, right, top = extent
-    custom_tms = TileMatrixSet.custom(
-        extent,
-        pyproj.CRS.from_epsg(6342),
-        decimation=decimation,
-    )
-    for z in [0, 1, 2, 3]:
-        tile_width = (right - left) / decimation**z
-        tile_height = (top - bottom) / decimation**z
-        expected = (left, top - tile_height, left + tile_width, top)
-        tile_bounds = custom_tms.xy_bounds(0, 0, z)
-        for a, b in zip(expected, tile_bounds):
-            assert round(a - b, 4) == 0
+    for decimation in [2, 3, 4, 5]:
+        custom_tms = TileMatrixSet.custom(
+            extent,
+            pyproj.CRS.from_epsg(6342),
+            decimation=decimation,
+        )
+        for zoom in [0, 1, 2, 3]:
+            tile_width = (right - left) / decimation**zoom
+            tile_height = (top - bottom) / decimation**zoom
+            expected = (left, top - tile_height, left + tile_width, top)
+            tile_bounds = custom_tms.xy_bounds(0, 0, zoom)
+            for a, b in zip(expected, tile_bounds):
+                assert round(a - b, 4) == 0
 
 
 def test_nztm_quad_is_quad():


### PR DESCRIPTION
I have a use case where I'd like to define a custom TileMatrixSet that uses a nonary-tree instead of quad-tree (i.e. divide by `3` at each zoom level instead of `2`.)

By default, `TileMatrixSet.custom` uses a hardcoded value of `2` for a quad-tree. This PR adds a `decimation` argument to allow for other divisions when generating a `TileMatrix` at each zoom level. The default value for `decimation` is set to `2` so existing tools are unaffected. This PR also includes tests.