### PR TITLE
fix: handle 180th meridian case for `tms.tiles()`

### DIFF
--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -1254,14 +1254,14 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
             # Clamp bounding values.
             w = (
                 max(self.bbox.left, w)
-                if self.bbox.left * w > 0  # case where we cross 180th meridian
-                else min(self.bbox.left, w)
+                if self.bbox.left * w > 0
+                else min(self.bbox.left, w)  # case where we cross 180th meridian
             )
             s = max(self.bbox.bottom, s)
             e = (
                 min(self.bbox.right, e)
-                if self.bbox.right * e > 0  # case where we cross 180th meridian
-                else max(self.bbox.right, e)
+                if self.bbox.right * e > 0
+                else max(self.bbox.right, e)  # case where we cross 180th meridian
             )
             n = min(self.bbox.top, n)
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -1252,9 +1252,17 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
 
         for w, s, e, n in bboxes:
             # Clamp bounding values.
-            w = max(self.bbox.left, w)
+            w = (
+                max(self.bbox.left, w)
+                if self.bbox.left * w > 0  # case where we cross 180th meridian
+                else min(self.bbox.left, w)
+            )
             s = max(self.bbox.bottom, s)
-            e = min(self.bbox.right, e)
+            e = (
+                min(self.bbox.right, e)
+                if self.bbox.right * e > 0  # case where we cross 180th meridian
+                else max(self.bbox.right, e)
+            )
             n = min(self.bbox.top, n)
 
             for z in zooms:

--- a/morecantile/utils.py
+++ b/morecantile/utils.py
@@ -40,6 +40,30 @@ def _parse_tile_arg(*args) -> Tile:
         )
 
 
+def lons_contain_antimeridian(lon1: float, lon2: float) -> bool:
+    """
+    Check if the antimeridian (180th meridian) is between two longitude points
+
+    Parameters
+    ----------
+    lon1: float
+        The first longitude.
+    lon2: float
+        The second longitude
+
+    Returns
+    -------
+    A bool representing whether two longs contain the 180th meridian.
+    """
+    lon1_clipped = max(-180.0, min(lon1, 180))
+    lon2_clipped = max(-180.0, min(lon2, 180))
+    lon1_converted = (lon1_clipped + 360) % 360
+    lon2_converted = (lon2_clipped + 360) % 360
+    ws = [lon1_converted, lon2_converted]
+    sorted(ws)
+    return ws[0] < 180 < ws[1]
+
+
 def meters_per_unit(crs: CRS) -> float:
     """
     Coefficient to convert the coordinate reference system (CRS)

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -396,6 +396,21 @@ def test_tiles():
     assert len(list(tms.tiles(*bounds, zooms=[2]))) == 2
 
 
+def test_tiles_when_tms_bounds_and_provided_bounds_cross_antimeridian():
+    bounds = (119.1, -32.86, 119.2, -32.82)
+    utm = CRS.from_epsg(32750)
+    rs_extent = utm.area_of_use.bounds
+    tms = morecantile.TileMatrixSet.custom(
+        crs=utm, extent_crs=CRS.from_epsg(4326), extent=list(rs_extent)
+    )
+    # tms.tiles needs to be aware if tms bounds and input bounds crosses the
+    # antimeridian e.g. min(119.2, -158.605) clamps to much larger area. Now
+    # that we check to see if lons contain antimeridian, we build tiles that
+    # actually overlap the provided bounds to tiles.
+    assert tms.bbox == (100.23646734667152, -79.99407435445299, -158.6052850376368, 0.0)
+    assert len(list(tms.tiles(*bounds, zooms=4))) == 1
+
+
 def test_tiles_for_tms_with_non_standard_row_col_order():
     """Test tiles from bbox when TMS has non-standard row/col alignment with lat/lon."""
     crs = CRS.from_proj4(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,3 +33,10 @@ from morecantile import utils
 def test_mpu(crs, unit):
     """test meters_per_unit."""
     assert utils.meters_per_unit(crs) == unit
+
+
+@pytest.mark.parametrize(
+    "lon1, lon2, contains", [(-180, 180, False), (179, -179, True)]
+)
+def test_lons_contain_antimeridian(lon1: float, lon2: float, contains: bool):
+    assert utils.lons_contain_antimeridian(lon1, lon2) == contains


### PR DESCRIPTION
👋

I ran into a strange case when my bbox for of a custom tms crossed the 180th meridian. Happy to add a test, but I now at least see expected results. Here is my example:

```python
import pyproj
import geopandas as gpd
from pyproj import CRS
from morecantile import TileMatrixSet
from shapely.geometry import box


def get_utm_tiles(bbox) -> gpd.GeoDataFrame:
    geo = gpd.GeoDataFrame(geometry=[bbox], crs=4326)
    utm = geo.estimate_utm_crs()
    print(utm)
    rs_extent = utm.area_of_use.bounds
    tms = TileMatrixSet.custom(crs=utm, extent_crs=CRS.from_epsg(4326), extent=list(rs_extent))
    tiles = list(tms.tiles(*geo.total_bounds, zooms=4))

    # transform back in order to investigate with gpd + .explore()
    transform = pyproj.Transformer.from_crs(utm, 4326, always_xy=True)
    geos = [box(*transform.transform_bounds(*list(tms.xy_bounds(t)), densify_pts=21)) for t in tiles]
    return gpd.GeoDataFrame(geometry=geos, crs=4326)


# all relatively small; should be covered by at most 4 tiles w/ zoom 8
# works as expected
bbox1 = box(-110.80, 44.58, -110.72, 44.66)
# case: utm=32750 which generates tms.bbox that overlaps 180th meridian
bbox2 = box(119.1, -32.86, 119.2, -32.82)

print(len(get_utm_tiles(bbox1)))  # >>> 1
print(len(get_utm_tiles(bbox2)))  # >>> 150!
```

With the change here, we now see only 1 intersected tile and no longer see the warning that a point is not in the bounds of the tms. Happy to add this as an edge case for testing if this seems like a reasonable change! Open to other approaches as well. Would there be another place in the code base that should also handle this case?