### PR TITLE
update to ensure self._geographic_crs will be a pyproj CRS object. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     - '*'
   pull_request:
 env:
-  LATEST_PY_VERSION: '3.10'
+  LATEST_PY_VERSION: '3.12'
 
 jobs:
   tests:
@@ -20,6 +20,7 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
+        - '3.12'
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+## 5.4.1 (2024-08-27)
+
+* ensure `TileMatrixSet._geographic_crs` is a pyproj CRS object (author @AndrewAnnex, https://github.com/developmentseed/morecantile/pull/152)
+
 ## 5.4.0 (2024-08-20)
 
 * adds --tms optional argument to the shapes and tiles cli tools (author @AndrewAnnex, https://github.com/developmentseed/morecantile/pull/151)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ## 5.4.1 (2024-08-27)
 
 * ensure `TileMatrixSet._geographic_crs` is a pyproj CRS object (author @AndrewAnnex, https://github.com/developmentseed/morecantile/pull/152)
+* add `python 3.12` support
 
 ## 5.4.0 (2024-08-20)
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -1,7 +1,6 @@
 """Pydantic modules for OGC TileMatrixSets (https://www.ogc.org/standards/tms)"""
 
 import math
-import sys
 import warnings
 from functools import cached_property
 from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple, Union
@@ -18,6 +17,7 @@ from pydantic import (
     model_validator,
 )
 from pyproj.exceptions import CRSError, ProjError
+from typing_extensions import Annotated
 
 from morecantile.commons import BoundingBox, Coords, Tile
 from morecantile.errors import (
@@ -36,11 +36,6 @@ from morecantile.utils import (
     point_in_bbox,
     to_rasterio_crs,
 )
-
-if sys.version_info >= (3, 9):
-    from typing import Annotated  # pylint: disable=no-name-in-module
-else:
-    from typing_extensions import Annotated
 
 NumType = Union[float, int]
 BoundsType = Tuple[NumType, NumType]
@@ -499,7 +494,9 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         """Set private attributes."""
         super().__init__(**data)
 
-        self._geographic_crs = pyproj.CRS.from_user_input(data.get("_geographic_crs", WGS84_CRS))
+        self._geographic_crs = pyproj.CRS.from_user_input(
+            data.get("_geographic_crs", WGS84_CRS)
+        )
 
         try:
             self._to_geographic = pyproj.Transformer.from_crs(

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -499,7 +499,7 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         """Set private attributes."""
         super().__init__(**data)
 
-        self._geographic_crs = data.get("_geographic_crs", WGS84_CRS)
+        self._geographic_crs = pyproj.CRS.from_user_input(data.get("_geographic_crs", WGS84_CRS))
 
         try:
             self._to_geographic = pyproj.Transformer.from_crs(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: GIS",
 ]
 dynamic = ["version"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -162,6 +162,19 @@ def test_Custom():
     assert round(wmMat.scaleDenominator, 6) == round(cusMat.scaleDenominator, 6)
     assert round(wmMat.pointOfOrigin[0], 6) == round(cusMat.pointOfOrigin[0], 6)
 
+    extent = (-20037508.3427892, -20037508.3427892, 20037508.3427892, 20037508.3427892)
+    custom_tms = TileMatrixSet.custom(
+        extent, pyproj.CRS.from_epsg(3857), geographic_crs="epsg:4326"
+    )
+    assert isinstance(custom_tms._geographic_crs, pyproj.CRS)
+    assert custom_tms._geographic_crs == pyproj.CRS.from_epsg(4326)
+
+    extent = (-20037508.3427892, -20037508.3427892, 20037508.3427892, 20037508.3427892)
+    custom_tms = TileMatrixSet.custom(
+        extent, pyproj.CRS.from_epsg(3857), geographic_crs=pyproj.CRS.from_epsg(4326)
+    )
+    assert isinstance(custom_tms._geographic_crs, pyproj.CRS)
+
 
 def test_custom_tms_bounds_epsg4326():
     """Check bounds with epsg4326."""


### PR DESCRIPTION
Likely a lot more could be done here to error catch but this could be reasonably robust as is

This PR just ensures the private geographic_crs parameter will be a Pyproj CRS object (some TMS specs I am using define this with a URN that wasn't getting parsed at the right moment.