### PR TITLE
fix: handle utm west and east antimeridian

### DIFF
--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -1250,9 +1250,8 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
 
         for w, s, e, n in bboxes:
             # Clamp bounding values.
-            ws_contain_180th = lons_contain_antimeridian(w, self.bbox.left)
             es_contain_180th = lons_contain_antimeridian(e, self.bbox.right)
-            w = min(self.bbox.left, w) if ws_contain_180th else max(self.bbox.left, w)
+            w = max(self.bbox.left, w)
             s = max(self.bbox.bottom, s)
             e = max(self.bbox.right, e) if es_contain_180th else min(self.bbox.right, e)
             n = min(self.bbox.top, n)


### PR DESCRIPTION
I discovered another corner case I didn't test for. This PR adds another tests case in order to check we get the expected number of tiles for the case when the west bounds and west tms_bbox crosses the antimeridian, but also for the corresponding east component. 

This prevents a very very large number of tiles being returned for both cases. 