### PR TITLE
added two tests for mars crs's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # PyCharm:
 .idea
+
+# VSCode
+.vscode
+.vscode/

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -40,7 +40,6 @@ from morecantile.utils import (
 NumType = Union[float, int]
 BoundsType = Tuple[NumType, NumType]
 LL_EPSILON = 1e-11
-WGS84_CRS = pyproj.CRS.from_epsg(4326)
 axesInfo = Annotated[List[str], Field(min_length=2, max_length=2)]
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -399,7 +399,10 @@ def test_mars_tms_construction():
     mars_sphere_crs = pyproj.CRS.from_user_input("IAU_2015:49900")
     extent = [-90, -180, 90, 180]
     mars_tms = morecantile.TileMatrixSet.custom(
-        extent, mars_sphere_crs, id="MarsGeographicCRS"
+        extent, 
+        mars_sphere_crs, 
+        id="MarsGeographicCRS", 
+        matrix_scale=[1, 2],
     )
     assert "4326" not in mars_tms.geographic_crs.to_wkt()
     assert "4326" not in mars_tms.rasterio_geographic_crs.to_wkt()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -413,22 +413,26 @@ def test_mars_tms_construction():
 
 
 def test_mars_web_mercator_long_lat():
-    mars_sphere_crs = pyproj.CRS.from_user_input("IAU_2015:49900")
-    wkt_mars_web_mercator = 'PROJCRS["Mars (2015) - Sphere XY / Pseudo-Mercator",BASEGEOGCRS["Mars (2015) - Sphere",DATUM["Mars (2015) - Sphere",ELLIPSOID["Mars (2015) - Sphere",3396190,0,LENGTHUNIT["metre",1,ID["EPSG",9001]]],ANCHOR["Viking 1 lander : 47.95137 W"]],PRIMEM["Reference Meridian",0,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06 S and 85.06 N."],BBOX[-85.850511287,-180,85.0511287,180]],REMARK["Use semi-major radius as sphere radius for interoperability. Source of IAU Coordinate systems: doi:10.1007/s10569-017-9805-5"]]'
+    wkt_mars_web_mercator = 'PROJCRS["Mars (2015) - Sphere XY / Pseudo-Mercator",BASEGEOGCRS["Mars (2015) - Sphere",DATUM["Mars (2015) - Sphere",ELLIPSOID["Mars (2015) - Sphere",3396190,0,LENGTHUNIT["metre",1,ID["EPSG",9001]]],ANCHOR["Viking 1 lander : 47.95137 W"]],PRIMEM["Reference Meridian",0,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06 S and 85.06 N."],BBOX[-85.050511287,-180,85.050511287,180]],REMARK["Use semi-major radius as sphere radius for interoperability. Source of IAU Coordinate systems: doi:10.1007/s10569-017-9805-5"]]'
     crs_mars_web_mercator = pyproj.CRS.from_wkt(wkt_mars_web_mercator)
-    extent_wm = [-180.0, -85.850511287, 180.0, 85.850511287]
+    extent_wm = [
+        -10669445.554195119,
+        -10669445.554195119,
+        10669445.554195119,
+        10669445.554195119,
+    ]
     mars_tms_wm = morecantile.TileMatrixSet.custom(
         extent_wm,
-        extent_crs=mars_sphere_crs,
+        # extent_crs=mars_sphere_crs,
         crs=crs_mars_web_mercator,
         id="MarsWebMercator",
     )
     assert "4326" not in mars_tms_wm.geographic_crs.to_wkt()
     assert "4326" not in mars_tms_wm.rasterio_geographic_crs.to_wkt()
     assert mars_tms_wm.bbox.left == pytest.approx(-180.0)
-    assert mars_tms_wm.bbox.bottom == pytest.approx(-85.850511287)
+    assert mars_tms_wm.bbox.bottom == pytest.approx(-85.0511287)
     assert mars_tms_wm.bbox.right == pytest.approx(180.0)
-    assert mars_tms_wm.bbox.top == pytest.approx(85.850511287)
+    assert mars_tms_wm.bbox.top == pytest.approx(85.0511287)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -432,6 +432,23 @@ def test_mars_web_mercator_long_lat():
     assert mars_tms_wm.bbox.bottom == pytest.approx(-85.0511287)
     assert mars_tms_wm.bbox.right == pytest.approx(180.0)
     assert mars_tms_wm.bbox.top == pytest.approx(85.0511287)
+    extent_wm_geog = [
+        -179.9999999999996,
+        -85.05112877980656,
+        179.9999999999996,
+        85.05112877980656,
+    ]
+    mars_sphere_crs = pyproj.CRS.from_user_input("IAU_2015:49900")
+    mars_tms_wm_geog_ext = morecantile.TileMatrixSet.custom(
+        extent_wm_geog,
+        extent_crs=mars_sphere_crs,
+        crs=crs_mars_web_mercator,
+        id="MarsWebMercator",
+    )
+    assert mars_tms_wm_geog_ext.bbox.left == pytest.approx(-180.0)
+    assert mars_tms_wm_geog_ext.bbox.bottom == pytest.approx(-85.0511287)
+    assert mars_tms_wm_geog_ext.bbox.right == pytest.approx(180.0)
+    assert mars_tms_wm_geog_ext.bbox.top == pytest.approx(85.0511287)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -397,19 +397,18 @@ def test_mars_local_tms():
 
 def test_mars_tms_construction():
     mars_sphere_crs = pyproj.CRS.from_user_input("IAU_2015:49900")
-    extent = [-90, -180, 90, 180]
+    extent = [-180.0, -90.0, 180.0, 90.0]
     mars_tms = morecantile.TileMatrixSet.custom(
         extent,
-        extent_crs=mars_sphere_crs,
         crs=mars_sphere_crs,
         id="MarsGeographicCRS",
-        matrix_scale=[1, 2],
+        matrix_scale=[2, 1],
     )
     assert "4326" not in mars_tms.geographic_crs.to_wkt()
     assert "4326" not in mars_tms.rasterio_geographic_crs.to_wkt()
-    assert mars_tms.xy_bbox.left == pytest.approx(-90.0)
+    assert mars_tms.xy_bbox.left == pytest.approx(-180.0)
+    assert mars_tms.xy_bbox.bottom == pytest.approx(-90.0)
     assert mars_tms.xy_bbox.right == pytest.approx(180.0)
-    assert mars_tms.xy_bbox.bottom == pytest.approx(180.0)
     assert mars_tms.xy_bbox.top == pytest.approx(90.0)
 
 
@@ -417,7 +416,7 @@ def test_mars_web_mercator_long_lat():
     mars_sphere_crs = pyproj.CRS.from_user_input("IAU_2015:49900")
     wkt_mars_web_mercator = 'PROJCRS["Mars (2015) - Sphere XY / Pseudo-Mercator",BASEGEOGCRS["Mars (2015) - Sphere",DATUM["Mars (2015) - Sphere",ELLIPSOID["Mars (2015) - Sphere",3396190,0,LENGTHUNIT["metre",1,ID["EPSG",9001]]],ANCHOR["Viking 1 lander : 47.95137 W"]],PRIMEM["Reference Meridian",0,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06 S and 85.06 N."],BBOX[-85.850511287,-180,85.0511287,180]],REMARK["Use semi-major radius as sphere radius for interoperability. Source of IAU Coordinate systems: doi:10.1007/s10569-017-9805-5"]]'
     crs_mars_web_mercator = pyproj.CRS.from_wkt(wkt_mars_web_mercator)
-    extent_wm = [-85.850511287, -180, 85.850511287, 180]
+    extent_wm = [-180.0, -85.850511287, 180.0, 85.850511287]
     mars_tms_wm = morecantile.TileMatrixSet.custom(
         extent_wm,
         extent_crs=mars_sphere_crs,
@@ -427,8 +426,8 @@ def test_mars_web_mercator_long_lat():
     assert "4326" not in mars_tms_wm.geographic_crs.to_wkt()
     assert "4326" not in mars_tms_wm.rasterio_geographic_crs.to_wkt()
     assert mars_tms_wm.bbox.left == pytest.approx(-180.0)
-    assert mars_tms_wm.bbox.right == pytest.approx(180.0)
     assert mars_tms_wm.bbox.bottom == pytest.approx(-85.850511287)
+    assert mars_tms_wm.bbox.right == pytest.approx(180.0)
     assert mars_tms_wm.bbox.top == pytest.approx(85.850511287)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -395,6 +395,35 @@ def test_mars_local_tms():
     assert bbox == syrtis_tms.bbox
 
 
+def test_mars_tms_construction():
+    mars_sphere_crs = pyproj.CRS.from_user_input("IAU_2015:49900")
+    extent = [-90, -180, 90, 180]
+    mars_tms = morecantile.TileMatrixSet.custom(
+        extent, mars_sphere_crs, id="MarsGeographicCRS"
+    )
+    assert "4326" not in mars_tms.geographic_crs.to_wkt()
+    assert "4326" not in mars_tms.rasterio_geographic_crs.to_wkt()
+    assert mars_tms.xy_bbox.left == pytest.approx(-90.0)
+    assert mars_tms.xy_bbox.right == pytest.approx(180.0)
+    assert mars_tms.xy_bbox.bottom == pytest.approx(180.0)
+    assert mars_tms.xy_bbox.top == pytest.approx(90.0)
+
+
+def test_mars_web_mercator_long_lat():
+    wkt_mars_web_mercator = 'PROJCRS["Mars (2015) - Sphere XY / Pseudo-Mercator",BASEGEOGCRS["Mars (2015) - Sphere",DATUM["Mars (2015) - Sphere",ELLIPSOID["Mars (2015) - Sphere",3396190,0,LENGTHUNIT["metre",1,ID["EPSG",9001]]],ANCHOR["Viking 1 lander : 47.95137 W"]],PRIMEM["Reference Meridian",0,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06 S and 85.06 N."],BBOX[-85.850511287,-180,85.0511287,180]],REMARK["Use semi-major radius as sphere radius for interoperability. Source of IAU Coordinate systems: doi:10.1007/s10569-017-9805-5"]]'
+    crs_mars_web_mercator = pyproj.CRS.from_wkt(wkt_mars_web_mercator)
+    extent_wm = [-85.850511287, -180, 85.0511287, 180]
+    mars_tms_wm = morecantile.TileMatrixSet.custom(
+        extent_wm, crs_mars_web_mercator, id="MarsWebMercator"
+    )
+    assert "4326" not in mars_tms_wm.geographic_crs.to_wkt()
+    assert "4326" not in mars_tms_wm.rasterio_geographic_crs.to_wkt()
+    assert mars_tms_wm.bbox.left == pytest.approx(-180.0)
+    assert mars_tms_wm.bbox.right == pytest.approx(180.0)
+    assert mars_tms_wm.bbox.bottom == pytest.approx(-85.850511287)
+    assert mars_tms_wm.bbox.top == pytest.approx(85.850511287)
+
+
 @pytest.mark.parametrize(
     "identifier, file, crs",
     [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -399,9 +399,10 @@ def test_mars_tms_construction():
     mars_sphere_crs = pyproj.CRS.from_user_input("IAU_2015:49900")
     extent = [-90, -180, 90, 180]
     mars_tms = morecantile.TileMatrixSet.custom(
-        extent, 
-        mars_sphere_crs, 
-        id="MarsGeographicCRS", 
+        extent,
+        extent_crs=mars_sphere_crs,
+        crs=mars_sphere_crs,
+        id="MarsGeographicCRS",
         matrix_scale=[1, 2],
     )
     assert "4326" not in mars_tms.geographic_crs.to_wkt()
@@ -413,11 +414,15 @@ def test_mars_tms_construction():
 
 
 def test_mars_web_mercator_long_lat():
+    mars_sphere_crs = pyproj.CRS.from_user_input("IAU_2015:49900")
     wkt_mars_web_mercator = 'PROJCRS["Mars (2015) - Sphere XY / Pseudo-Mercator",BASEGEOGCRS["Mars (2015) - Sphere",DATUM["Mars (2015) - Sphere",ELLIPSOID["Mars (2015) - Sphere",3396190,0,LENGTHUNIT["metre",1,ID["EPSG",9001]]],ANCHOR["Viking 1 lander : 47.95137 W"]],PRIMEM["Reference Meridian",0,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06 S and 85.06 N."],BBOX[-85.850511287,-180,85.0511287,180]],REMARK["Use semi-major radius as sphere radius for interoperability. Source of IAU Coordinate systems: doi:10.1007/s10569-017-9805-5"]]'
     crs_mars_web_mercator = pyproj.CRS.from_wkt(wkt_mars_web_mercator)
-    extent_wm = [-85.850511287, -180, 85.0511287, 180]
+    extent_wm = [-85.850511287, -180, 85.850511287, 180]
     mars_tms_wm = morecantile.TileMatrixSet.custom(
-        extent_wm, crs_mars_web_mercator, id="MarsWebMercator"
+        extent_wm,
+        extent_crs=mars_sphere_crs,
+        crs=crs_mars_web_mercator,
+        id="MarsWebMercator",
     )
     assert "4326" not in mars_tms_wm.geographic_crs.to_wkt()
     assert "4326" not in mars_tms_wm.rasterio_geographic_crs.to_wkt()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -423,7 +423,6 @@ def test_mars_web_mercator_long_lat():
     ]
     mars_tms_wm = morecantile.TileMatrixSet.custom(
         extent_wm,
-        # extent_crs=mars_sphere_crs,
         crs=crs_mars_web_mercator,
         id="MarsWebMercator",
     )


### PR DESCRIPTION
Adds two tests that are currently failing to correctly return the expected xy_bbox or bbox for the two CRSs considered. 
not sure why but somehow using IAU CRSs that are inverted (latitude longitude order) doesn't seem to work with the latest #158. Maybe this `_pyproj_crs.geodetic_crs` switching around the axes?