### PR TITLE
add warning when non wgs84 geographic crs and optional wgs84 default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 # VSCode
 .vscode
 .vscode/
+
+.notebooks/

--- a/morecantile/errors.py
+++ b/morecantile/errors.py
@@ -35,3 +35,7 @@ class InvalidZoomError(MorecantileError):
 
 class DeprecationError(MorecantileError):
     """Raised when TMS version is not 2.0"""
+
+
+class NonWGS84GeographicCRS(UserWarning):
+    """Geographic CRS is not EPSG:4326."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,12 @@ ignore = [
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:You will likely lose important projection*:UserWarning",
+    "ignore:`CanadianNAD83_LCC`*:morecantile.errors.NonWGS84GeographicCRS",
+    "ignore:`EuropeanETRS89_LAEAQuad`*:morecantile.errors.NonWGS84GeographicCRS",
+    "ignore:`WorldCRS84Quad`*:morecantile.errors.NonWGS84GeographicCRS",
+    "ignore:`NZTM2000Quad`*:morecantile.errors.NonWGS84GeographicCRS",
+    "ignore:`LINZAntarticaMapTilegrid`*:morecantile.errors.NonWGS84GeographicCRS",
+    "ignore::morecantile.errors.PointOutsideTMSBounds",
 ]
 
 [tool.bumpversion]

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -11,6 +11,7 @@ import morecantile
 from morecantile.errors import (
     InvalidIdentifier,
     InvalidZoomError,
+    NonWGS84GeographicCRS,
     PointOutsideTMSBounds,
 )
 from morecantile.utils import is_power_of_two, meters_per_unit
@@ -439,7 +440,8 @@ def test_tiles_for_tms_with_non_standard_row_col_order():
         "+proj=s2 +lat_0=0.0 +lon_0=-90.0 +ellps=WGS84 +UVtoST=quadratic"
     )
     extent = [0.0, 0.0, 1.0, 1.0]
-    s2f4 = morecantile.TileMatrixSet.custom(extent, crs, id="S2F4")
+    with pytest.warns(NonWGS84GeographicCRS):
+        s2f4 = morecantile.TileMatrixSet.custom(extent, crs, id="S2F4")
     overlapping_tiles = s2f4.tiles(-100, 27, -95, 33, [6])
     assert len(list(overlapping_tiles)) == 30
 


### PR DESCRIPTION
closes #165 

This PR does:

- add `_geographic_crs` private attribute (again)
- add 2 env variable control:
    -  `MORECANTILE_IGNORE_NON_WGS84_GEOGRAPHIC`: silent warning when geographic CRS is not WGS84
    - `MORECANTILE_WGS84_GEOGRAPHIC`: make WGS84 the default geographic CRS


@AndrewAnnex any opinions?