### PR TITLE
Upgrading pyproj to 3.7.0 and tests to cover Python 3.13 and 3.14.0-alpha.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
-
+        - '3.13'
+        - '3.14.0-alpha.2'
+        
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "attrs",
-    "pyproj~=3.1",
+    "pyproj~=3.7",
     "pydantic~=2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "attrs",
-    "pyproj~=3.7",
+    "pyproj<3.7",
     "pydantic~=2.0",
 ]
 


### PR DESCRIPTION
I tested this on my machine and pyproj 3.7.0 doesn't trigger any issues with any of the unit tests.

```bash
$ pip install -U pyproj
```

```
Requirement already satisfied: pyproj in /home/mark/.morecantile/lib/python3.10/site-packages (3.7.0)
Requirement already satisfied: certifi in /home/mark/.morecantile/lib/python3.10/site-packages (from pyproj) (2024.8.30)
```

```bash
$ python3 -m pytest mercantile -s -vv | tail
```

```
mercantile/tests/test_funcs.py::test_geojson_bounds[obj0] PASSED
mercantile/tests/test_funcs.py::test_geojson_bounds[obj1] PASSED
mercantile/tests/test_funcs.py::test_geojson_bounds[obj2] PASSED
mercantile/tests/test_funcs.py::test_geojson_bounds[obj3] PASSED
mercantile/tests/test_funcs.py::test_xy_future_warnings[0-1] PASSED
mercantile/tests/test_funcs.py::test_xy_future_warnings[1-0] PASSED
mercantile/tests/test_funcs.py::test_xy_future_warnings[-1-0] PASSED
mercantile/tests/test_funcs.py::test_xy_future_warnings[0--1] PASSED

============================= 136 passed in 0.62s ==============================
```