### PR TITLE
Add support for bottomLeft cornerOfOrigin

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import os.path
+import pathlib
+
+import pytest
+
+from morecantile import tms
+
+
+@pytest.fixture(scope="session", autouse=True)
+def register_WebMercatorQuadBottomLeft():
+    """Automatically load in WebMercatorQuadBottomLeft once as the start of the testing session"""
+    directory = os.path.split(__file__)[0]
+    file_path = os.path.join(directory, "fixtures", "bottomLeft_tms", "WebMercatorQuadBottomLeft.json")
+    path_obj = pathlib.Path(file_path)
+    tms.tms["WebMercatorQuadBottomLeft"] = path_obj
+    # Load
+    tms.get("WebMercatorQuadBottomLeft")

--- a/tests/fixtures/bottomLeft_tms/WebMercatorQuadBottomLeft.json
+++ b/tests/fixtures/bottomLeft_tms/WebMercatorQuadBottomLeft.json
@@ -1,0 +1,286 @@
+{
+   "id": "WebMercatorQuadBottomLeft",
+   "title": "Google Maps Compatible for the World",
+   "uri": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+   "crs": "http://www.opengis.net/def/crs/EPSG/0/3857",
+   "orderedAxes": ["X", "Y"],
+   "wellKnownScaleSet": "http://www.opengis.net/def/wkss/OGC/1.0/GoogleMapsCompatible",
+   "tileMatrices":
+   [
+      {
+        "id": "0",
+        "scaleDenominator": 559082264.028717,
+        "cellSize": 156543.033928041,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 1,
+        "matrixHeight": 1
+      },
+      {
+        "id": "1",
+        "scaleDenominator": 279541132.014358,
+        "cellSize": 78271.5169640204,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 2,
+        "matrixHeight": 2
+      },
+      {
+        "id": "2",
+        "scaleDenominator": 139770566.007179,
+        "cellSize": 39135.7584820102,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 4,
+        "matrixHeight": 4
+      },
+      {
+        "id": "3",
+        "scaleDenominator": 69885283.0035897,
+        "cellSize": 19567.8792410051,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 8,
+        "matrixHeight": 8
+      },
+      {
+        "id": "4",
+        "scaleDenominator": 34942641.5017948,
+        "cellSize": 9783.93962050256,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 16,
+        "matrixHeight": 16
+      },
+      {
+        "id": "5",
+        "scaleDenominator": 17471320.7508974,
+        "cellSize": 4891.96981025128,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 32,
+        "matrixHeight": 32
+      },
+      {
+        "id": "6",
+        "scaleDenominator": 8735660.37544871,
+        "cellSize": 2445.98490512564,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 64,
+        "matrixHeight": 64
+      },
+      {
+        "id": "7",
+        "scaleDenominator": 4367830.18772435,
+        "cellSize": 1222.99245256282,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 128,
+        "matrixHeight": 128
+      },
+      {
+        "id": "8",
+        "scaleDenominator": 2183915.09386217,
+        "cellSize": 611.49622628141,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 256,
+        "matrixHeight": 256
+      },
+      {
+        "id": "9",
+        "scaleDenominator": 1091957.54693108,
+        "cellSize": 305.748113140704,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 512,
+        "matrixHeight": 512
+      },
+      {
+        "id": "10",
+        "scaleDenominator": 545978.773465544,
+        "cellSize": 152.874056570352,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 1024,
+        "matrixHeight": 1024
+      },
+      {
+        "id": "11",
+        "scaleDenominator": 272989.386732772,
+        "cellSize": 76.4370282851762,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 2048,
+        "matrixHeight": 2048
+      },
+      {
+        "id": "12",
+        "scaleDenominator": 136494.693366386,
+        "cellSize": 38.2185141425881,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 4096,
+        "matrixHeight": 4096
+      },
+      {
+        "id": "13",
+        "scaleDenominator": 68247.346683193,
+        "cellSize": 19.109257071294,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 8192,
+        "matrixHeight": 8192
+      },
+      {
+        "id": "14",
+        "scaleDenominator": 34123.6733415964,
+        "cellSize": 9.55462853564703,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 16384,
+        "matrixHeight": 16384
+      },
+      {
+        "id": "15",
+        "scaleDenominator": 17061.8366707982,
+        "cellSize": 4.77731426782351,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 32768,
+        "matrixHeight": 32768
+      },
+      {
+        "id": "16",
+        "scaleDenominator": 8530.91833539913,
+        "cellSize": 2.38865713391175,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 65536,
+        "matrixHeight": 65536
+      },
+      {
+        "id": "17",
+        "scaleDenominator": 4265.45916769956,
+        "cellSize": 1.19432856695587,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 131072,
+        "matrixHeight": 131072
+      },
+      {
+        "id": "18",
+        "scaleDenominator": 2132.72958384978,
+        "cellSize": 0.597164283477939,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 262144,
+        "matrixHeight": 262144
+      },
+      {
+        "id": "19",
+        "scaleDenominator": 1066.36479192489,
+        "cellSize": 0.29858214173897,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 524288,
+        "matrixHeight": 524288
+      },
+      {
+        "id": "20",
+        "scaleDenominator": 533.182395962445,
+        "cellSize": 0.149291070869485,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 1048576,
+        "matrixHeight": 1048576
+      },
+      {
+        "id": "21",
+        "scaleDenominator": 266.591197981222,
+        "cellSize": 0.0746455354347424,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 2097152,
+        "matrixHeight": 2097152
+      },
+      {
+        "id": "22",
+        "scaleDenominator": 133.295598990611,
+        "cellSize": 0.0373227677173712,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 4194304,
+        "matrixHeight": 4194304
+      },
+      {
+        "id": "23",
+        "scaleDenominator": 66.6477994953056,
+        "cellSize": 0.0186613838586856,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 8388608,
+        "matrixHeight": 8388608
+      },
+      {
+        "id": "24",
+        "scaleDenominator": 33.3238997476528,
+        "cellSize": 0.0093306919293428,
+        "pointOfOrigin": [-20037508.342789244,-20037508.34278925],
+        "cornerOfOrigin": "bottomLeft",
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 16777216,
+        "matrixHeight": 16777216
+      }
+   ]
+}

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -16,11 +16,12 @@ from morecantile.errors import (
 from morecantile.utils import is_power_of_two, meters_per_unit
 
 DEFAULT_GRID_COUNT = 13
+TESTING_GRID_COUNT = 1
 
 
 def test_default_grids():
     """Morecantile.default_grids should return the correct list of grids."""
-    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT
+    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT + TESTING_GRID_COUNT
 
     with pytest.raises(InvalidIdentifier):
         morecantile.tms.get("ANotValidName")
@@ -28,7 +29,7 @@ def test_default_grids():
 
 def test_register():
     """Test register a new grid."""
-    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT
+    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT + TESTING_GRID_COUNT
 
     crs = CRS.from_epsg(3031)
     extent = [-948.75, -543592.47, 5817.41, -3333128.95]  # From https:///epsg.io/3031
@@ -36,10 +37,10 @@ def test_register():
 
     # Make sure we don't update the default tms (frozen set)
     _ = morecantile.tms.register({"MyCustomGrid3031": tms})
-    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT
+    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT + TESTING_GRID_COUNT
 
     defaults = morecantile.tms.register({"MyCustomGrid3031": tms})
-    assert len(defaults.list()) == DEFAULT_GRID_COUNT + 1
+    assert len(defaults.list()) == DEFAULT_GRID_COUNT + TESTING_GRID_COUNT + 1
     assert "MyCustomGrid3031" in defaults.list()
 
     # Check it will raise an exception if TMS is already registered
@@ -48,7 +49,7 @@ def test_register():
 
     # Do not raise is overwrite=True
     defaults = defaults.register({"MyCustomGrid3031": tms}, overwrite=True)
-    assert len(defaults.list()) == DEFAULT_GRID_COUNT + 1
+    assert len(defaults.list()) == DEFAULT_GRID_COUNT + TESTING_GRID_COUNT + 1
 
     # add tms in morecantile defaults (not something to do anyway)
     epsg3031 = morecantile.TileMatrixSet.custom(extent, crs, id="epsg3031")
@@ -56,11 +57,11 @@ def test_register():
     assert len(morecantile.defaults.default_tms.keys()) == DEFAULT_GRID_COUNT + 1
 
     # make sure updating the default_tms dict has no effect on the default TileMatrixSets
-    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT
+    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT + TESTING_GRID_COUNT
 
     # Update internal TMS dict
     morecantile.tms.tms["MyCustomGrid3031"] = tms
-    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT + 1
+    assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT + TESTING_GRID_COUNT + 1
 
     # make sure it doesn't propagate to the default dict
     assert "MyCustomGrid3031" not in morecantile.defaults.default_tms
@@ -106,9 +107,18 @@ def test_bounds(args):
 
 
 @pytest.mark.parametrize(
-    "args", [(486, 332, 10), [(486, 332, 10)], [morecantile.Tile(486, 332, 10)]]
+    ("tile_args", "identifier"),
+    [
+        ((486, 332, 10), "WebMercatorQuad"),
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuad"),
+
+        # bottomLeft tests. y should be matrixWidth-topLeft-1 to produce the same value as topLeft
+        ((486, 1023 - 332, 10), "WebMercatorQuadBottomLeft"),
+        (morecantile.Tile(486, 1023 - 332, 10), "WebMercatorQuadBottomLeft"),
+
+    ],
 )
-def test_xy_bounds(args):
+def test_xy_bounds(tile_args, identifier):
     """
     TileMatrixSet.xy_bounds should return the correct coordinates.
 
@@ -120,23 +130,33 @@ def test_xy_bounds(args):
         -978393.962050256,
         7044436.526761846,
     )
-    tms = morecantile.tms.get("WebMercatorQuad")
-    bounds = tms.xy_bounds(*args)
+    tms = morecantile.tms.get(identifier)
+    bounds = tms.xy_bounds(*tile_args)
     for a, b in zip(expected, bounds):
         assert round(a - b, 6) == 0
 
 
-def test_ul_tile():
+@pytest.mark.parametrize(
+    ("tile_args", "identifier", "expected"),
+    [
+        ((486, 332, 10), "WebMercatorQuad", (-9.140625, 53.33087298301705)),
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuad", (-9.140625, 53.33087298301705)),
+
+        ((486, 691, 10), "WebMercatorQuadBottomLeft", (-9.140625, 53.33087298301705)),
+        (morecantile.Tile(486, 691, 10), "WebMercatorQuadBottomLeft", (-9.140625, 53.33087298301705)),
+    ],
+)
+def test_ul_tile(tile_args, identifier, expected):
     """
     TileMatrixSet.ul should return the correct coordinates.
 
     test form https://github.com/mapbox/mercantile/blob/master/tests/test_funcs.py
     """
-    tms = morecantile.tms.get("WebMercatorQuad")
-    xy = tms.ul(486, 332, 10)
-    expected = (-9.140625, 53.33087298301705)
+    tms = morecantile.tms.get(identifier)
+    xy = tms.ul(*tile_args)
+    print(xy)
     for a, b in zip(expected, xy):
-        assert round(a - b, 6) == 0
+        assert round(a - b, 6) == pytest.approx(0)
 
 
 def test_projul_tile():
@@ -152,10 +172,17 @@ def test_projul_tile():
         assert round(a - b, 6) == 0
 
 
-def test_projtile():
+@pytest.mark.parametrize(
+    ("x", "y", "zoom", "identifier", "expected_tile"),
+    [
+        (1000, 1000, 1, 'WebMercatorQuad', morecantile.Tile(1, 0, 1)),
+        (1000, 1000, 1, 'WebMercatorQuadBottomLeft', morecantile.Tile(1, 1, 1))
+
+    ])
+def test_projtile(x, y, zoom, identifier, expected_tile):
     """TileSchema._tile should return the correct tile."""
-    tms = morecantile.tms.get("WebMercatorQuad")
-    assert tms._tile(1000, 1000, 1) == morecantile.Tile(1, 0, 1)
+    tms = morecantile.tms.get(identifier)
+    assert tms._tile(x, y, zoom) == expected_tile
 
 
 def test_feature():
@@ -193,13 +220,24 @@ def test_feature():
 # replicate mercantile tests
 # https://github.com/mapbox/mercantile/blob/master/tests/test_funcs.py
 @pytest.mark.parametrize(
-    "args", [(486, 332, 10), [(486, 332, 10)], [morecantile.Tile(486, 332, 10)]]
+    ("tile_args", "identifier", "expected"),
+    [
+
+        ((486, 332, 10), "WebMercatorQuad", (-9.140625, 53.33087298301705)),
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuad", (-9.140625, 53.33087298301705)),
+
+        ((486, 691, 10), "WebMercatorQuadBottomLeft", (-9.140625, 53.33087298301705)),
+        (morecantile.Tile(486, 691, 10), "WebMercatorQuadBottomLeft", (-9.140625, 53.33087298301705)),
+
+        (morecantile.Tile(0, 0, 0), "WebMercatorQuad", (-180, 85.0511287798066)),
+        (morecantile.Tile(0, 0, 0), "WebMercatorQuadBottomLeft", (-180, 85.0511287798066)),
+
+    ],
 )
-def test_ul(args):
+def test_ul(tile_args, identifier, expected):
     """test args."""
-    tms = morecantile.tms.get("WebMercatorQuad")
-    expected = (-9.140625, 53.33087298301705)
-    lnglat = tms.ul(*args)
+    tms = morecantile.tms.get(identifier)
+    lnglat = tms.ul(*tile_args)
     for a, b in zip(expected, lnglat):
         assert round(a - b, 6) == 0
     assert lnglat[0] == lnglat.x
@@ -207,13 +245,88 @@ def test_ul(args):
 
 
 @pytest.mark.parametrize(
-    "args", [(486, 332, 10), [(486, 332, 10)], [mercantile.Tile(486, 332, 10)]]
+    ("topLeft_Tile", "bottomLeft_Tile"),
+    [
+        (morecantile.Tile(10, 10, 10), morecantile.Tile(10, 1013, 10)),
+        (morecantile.Tile(10, 1013, 10), morecantile.Tile(10, 10, 10)),
+
+        # Check the Origin points
+        (morecantile.Tile(0, 0, 10), morecantile.Tile(0, 1023, 10)),
+        (morecantile.Tile(0, 1023, 10), morecantile.Tile(0, 0, 10)),
+
+        # Check the end points
+        (morecantile.Tile(1023, 0, 10), morecantile.Tile(1023, 1023, 10)),
+        (morecantile.Tile(1023, 1023, 10), morecantile.Tile(1023, 0, 10)),
+
+        # Zoom=0
+        (morecantile.Tile(0, 0, 0), morecantile.Tile(0, 0, 0)),
+
+        # zoom=1 on both edges of the zoom level
+        (morecantile.Tile(0, 0, 1), morecantile.Tile(0, 1, 1)),
+        (morecantile.Tile(0, 1, 1), morecantile.Tile(0, 0, 1)),
+
+        # zoom=14 near the middle
+        (morecantile.Tile(x=3413, y=6202, z=14), morecantile.Tile(x=3413, y=10181, z=14))
+    ]
 )
-def test_bbox(args):
+def test_topLeft_BottomLeft_bounds_equal_bounds(topLeft_Tile, bottomLeft_Tile):
+    tmsTop = morecantile.tms.get("WebMercatorQuad")
+    tmsBottom = morecantile.tms.get("WebMercatorQuadBottomLeft")
+
+    bounds = tmsTop.xy_bounds(topLeft_Tile)
+    bounds2 = tmsBottom.xy_bounds(bottomLeft_Tile)
+    for a, b in zip(bounds, bounds2):
+        assert round(a - b, 6) == 0
+
+
+@pytest.mark.parametrize(
+    ("topLeft_Tile", "bottomLeft_Tile"),
+    [
+        (morecantile.Tile(10, 10, 10), morecantile.Tile(10, 1013, 10)),
+        (morecantile.Tile(0, 0, 10), morecantile.Tile(0, 1023, 10)),
+
+        # Check the oring tile with zoom=0
+        (morecantile.Tile(0, 0, 0), morecantile.Tile(0, 0, 0)),
+
+        # Origin tile of zoom=1
+        (morecantile.Tile(0, 0, 1), morecantile.Tile(0, 1, 1)),
+        # last tile of zoom=1
+        (morecantile.Tile(1, 1, 1), morecantile.Tile(1, 0, 1)),
+        (morecantile.Tile(1, 1, 1), morecantile.Tile(1, 0, 1)),
+
+        # zoom=14 near the middle
+        (morecantile.Tile(x=3413, y=6202, z=14), morecantile.Tile(x=3413, y=10181, z=14))
+
+    ]
+)
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_translate_cornerOfOrigin_Tile(topLeft_Tile, bottomLeft_Tile, identifier):
+    tmsTop = morecantile.tms.get(identifier)
+    matrix = tmsTop.matrix(topLeft_Tile.z)
+
+    translated_tile = matrix.translate_cornerOfOrigin_Tile(topLeft_Tile)
+    assert translated_tile == bottomLeft_Tile
+
+    untranslated_tile = matrix.translate_cornerOfOrigin_Tile(translated_tile)
+    assert untranslated_tile == topLeft_Tile
+
+
+@pytest.mark.parametrize(
+    ("tile_args", "identifier", "expected"),
+    [
+        ((486, 332, 10), "WebMercatorQuad", (-9.140625, 53.12040528310657, -8.7890625, 53.33087298301705)),
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuad",
+         (-9.140625, 53.12040528310657, -8.7890625, 53.33087298301705)),
+
+        ((486, 691, 10), "WebMercatorQuadBottomLeft", (-9.140625, 53.12040528310657, -8.7890625, 53.33087298301705)),
+        (morecantile.Tile(486, 691, 10), "WebMercatorQuadBottomLeft",
+         (-9.140625, 53.12040528310657, -8.7890625, 53.33087298301705)),
+    ],
+)
+def test_bbox(tile_args, identifier, expected):
     """test bbox."""
-    tms = morecantile.tms.get("WebMercatorQuad")
-    expected = (-9.140625, 53.12040528310657, -8.7890625, 53.33087298301705)
-    bbox = tms.bounds(*args)
+    tms = morecantile.tms.get(identifier)
+    bbox = tms.bounds(*tile_args)
     for a, b in zip(expected, bbox):
         assert round(a - b, 6) == 0
     assert bbox.left == bbox[0]
@@ -222,19 +335,110 @@ def test_bbox(args):
     assert bbox.top == bbox[3]
 
 
-def test_xy_tile():
+@pytest.mark.parametrize(
+    ("tile", "identifier"),
+    [
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuad"),
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuadBottomLeft"),
+        # check origin
+        (morecantile.Tile(0, 0, 0), "WebMercatorQuad"),
+        (morecantile.Tile(0, 0, 0), "WebMercatorQuadBottomLeft"),
+        # Check final tiles
+        (morecantile.Tile(1, 1, 1), "WebMercatorQuad"),
+        (morecantile.Tile(1, 1, 1), "WebMercatorQuadBottomLeft"),
+    ])
+def test_bounding_box_ulurlllr(tile, identifier):
+    """Test that bounds and georeference functions return the same values"""
+    tms = morecantile.tms.get(identifier)
+    bbox = tms.bounds(*tile)
+    ul = tms.ul(*tile)
+    ll = tms.ll(*tile)
+    ur = tms.ur(*tile)
+    lr = tms.lr(*tile)
+
+    assert (ul.x, ul.y) == (bbox.left, bbox.top)
+    assert (ll.x, ll.y) == (bbox.left, bbox.bottom)
+    assert (ur.x, ur.y) == (bbox.right, bbox.top)
+    assert (lr.x, lr.y) == (bbox.right, bbox.bottom)
+
+
+@pytest.mark.parametrize(
+    ("tile", "identifier"),
+    [
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuad"),
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuadBottomLeft"),
+        # check origin
+        (morecantile.Tile(0, 0, 0), "WebMercatorQuad"),
+        (morecantile.Tile(0, 0, 0), "WebMercatorQuadBottomLeft"),
+        # Check final tiles
+        (morecantile.Tile(1, 1, 1), "WebMercatorQuad"),
+        (morecantile.Tile(1, 1, 1), "WebMercatorQuadBottomLeft"),
+    ])
+def test_tms_bounding_box_ulurlllr(tile, identifier):
+    """Test that xy_bounds and tms functions return the same values"""
+    tms = morecantile.tms.get(identifier)
+    bbox = tms.xy_bounds(*tile)
+    ul = tms._ul(*tile)
+    ll = tms._ll(*tile)
+    ur = tms._ur(*tile)
+    lr = tms._lr(*tile)
+
+    assert (ul.x, ul.y) == (bbox.left, bbox.top)
+    assert (ll.x, ll.y) == (bbox.left, bbox.bottom)
+    assert (ur.x, ur.y) == (bbox.right, bbox.top)
+    assert (lr.x, lr.y) == (bbox.right, bbox.bottom)
+
+
+@pytest.mark.parametrize(
+    ("tile", "identifier"),
+    [
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuad"),
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuadBottomLeft"),
+        # check origin
+        (morecantile.Tile(0, 0, 0), "WebMercatorQuad"),
+        (morecantile.Tile(0, 0, 0), "WebMercatorQuadBottomLeft"),
+        # Check final tiles
+        (morecantile.Tile(1, 1, 1), "WebMercatorQuad"),
+        (morecantile.Tile(1, 1, 1), "WebMercatorQuadBottomLeft"),
+    ])
+def test_origin_coords(tile, identifier):
+    tms = morecantile.tms.get(identifier)
+    matrix = tms.matrix(tile.z)
+    origin = tms.origin_coords(*tile)
+    across = tms.origin_coords_across(*tile)
+
+    if matrix.cornerOfOrigin == 'topLeft':
+        assert origin == tms.ul(*tile)
+        assert across == tms.lr(*tile)
+    elif matrix.cornerOfOrigin == 'bottomLeft':
+        assert origin == tms.ll(*tile)
+        assert across == tms.ur(*tile)
+    else:
+        raise NotImplementedError()
+
+
+@pytest.mark.parametrize(
+    ("tile_args", "identifier", "expected"),
+    [
+        (morecantile.Tile(486, 332, 10), "WebMercatorQuad", (-1017529.7205322663, 7044436.526761846)),
+        (morecantile.Tile(10, 10, 10), "WebMercatorQuad", (-19646150.757969137, 19646150.757969007)),
+        (morecantile.Tile(10, 1013, 10), "WebMercatorQuadBottomLeft", (-19646150.757969137, 19646150.757969007)),
+
+    ]
+)
+def test_xy_tile(tile_args, identifier, expected):
     """x, y for the 486-332-10 tile is correctly calculated."""
-    tms = morecantile.tms.get("WebMercatorQuad")
-    ul = tms.ul(486, 332, 10)
+    tms = morecantile.tms.get(identifier)
+    ul = tms.ul(*tile_args)
     xy = tms.xy(*ul)
-    expected = (-1017529.7205322663, 7044436.526761846)
     for a, b in zip(expected, xy):
         assert round(a - b, 6) == 0
 
 
-def test_xy_null_island():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_xy_null_island(identifier):
     """x, y for (0, 0) is correctly calculated"""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     xy = tms.xy(0.0, 0.0)
     expected = (0.0, 0.0)
     for a, b in zip(expected, xy):
@@ -267,9 +471,10 @@ def test_xy_north_pole():
         assert xy.y == float("inf")
 
 
-def test_xy_truncate():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_xy_truncate(identifier):
     """Input is truncated"""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     assert tms.xy(-181.0, 0.0, truncate=True) == tms.xy(tms.bbox.left, 0.0)
 
 
@@ -314,9 +519,10 @@ def test_lnglat_gdal3():
         assert round(lnglat.y, 5) == -14.70462
 
 
-def test_lnglat_xy_roundtrip():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_lnglat_xy_roundtrip(identifier):
     """Test roundtrip."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     lnglat = (-105.0844, 40.5853)
     roundtrip = tms.lnglat(*tms.xy(*lnglat))
     for a, b in zip(roundtrip, lnglat):
@@ -341,18 +547,26 @@ def test_xy_bounds_mercantile(args):
         assert round(a - b, 6) == 0
 
 
-def test_tile_not_truncated():
+@pytest.mark.parametrize(
+    ("identifier", "expected_tile"),
+    (
+
+            (["WebMercatorQuad", morecantile.Tile(285, 193, 9)]),
+            (["WebMercatorQuadBottomLeft", morecantile.Tile(285, 318, 9)])
+
+    )
+)
+def test_tile_not_truncated(identifier, expected_tile):
     """test tile."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     tile = tms.tile(20.6852, 40.1222, 9)
-    expected = (285, 193)
-    assert tile[0] == expected[0]
-    assert tile[1] == expected[1]
+    assert tile == expected_tile
 
 
-def test_tile_truncate():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_tile_truncate(identifier):
     """Input is truncated"""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     assert tms.tile(-181.0, 0.0, 9, truncate=True) == tms.tile(-180.0, 0.0, 9)
 
 
@@ -444,18 +658,20 @@ def test_tiles_for_tms_with_non_standard_row_col_order():
     assert len(list(overlapping_tiles)) == 30
 
 
-def test_global_tiles_clamped():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_global_tiles_clamped(identifier):
     """Y is clamped to (0, 2 ** zoom - 1)."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     tiles = list(tms.tiles(-180, -90, 180, 90, [1]))
     assert len(tiles) == 4
     assert min(t.y for t in tiles) == 0
     assert max(t.y for t in tiles) == 1
 
 
-def test_tiles_roundtrip_children():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_tiles_roundtrip_children(identifier):
     """tiles(bounds(tile)) gives the tile's children"""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     t = morecantile.Tile(x=3413, y=6202, z=14)
     res = list(tms.tiles(*tms.bounds(t), zooms=[15]))
     assert len(res) == 4
@@ -469,10 +685,12 @@ def test_tiles_roundtrip_children():
         morecantile.Tile(10, 10, 10),
     ],
 )
-def test_tiles_roundtrip(t):
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_tiles_roundtrip(t, identifier):
     """Tiles(bounds(tile)) gives the tile."""
-    tms = morecantile.tms.get("WebMercatorQuad")
-    res = list(tms.tiles(*tms.bounds(t), zooms=[t.z]))
+    tms = morecantile.tms.get(identifier)
+    bounds = tms.bounds(t)
+    res = list(tms.tiles(*bounds, zooms=[t.z]))
     assert len(res) == 1
     val = res.pop()
     assert val.x == t.x
@@ -480,21 +698,23 @@ def test_tiles_roundtrip(t):
     assert val.z == t.z
 
 
-def test_tiles_nan_bounds():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_tiles_nan_bounds(identifier):
     """
     nan bounds should raise an error instead of getting clamped to avoid
     unintentionally generating tiles for the entire TMS' extent.
     """
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
 
     bounds = (-105, math.nan, -104.99, 40)
     with pytest.raises(ValueError):
         list(tms.tiles(*bounds, zooms=[14]))
 
 
-def test_extend_zoom():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad"])
+def test_extend_zoom(identifier):
     """TileMatrixSet.ul should return the correct coordinates."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     merc = mercantile.xy_bounds(1000, 1000, 25)
     with pytest.warns(UserWarning):
         more = tms.xy_bounds(1000, 1000, 25)
@@ -534,15 +754,17 @@ def test_is_power_of_two():
         (morecantile.Tile(0, 0, -1), False),
     ],
 )
-def test_is_valid_tile(t, res):
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_is_valid_tile(t, res, identifier):
     """test if tile are valid."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     assert tms.is_valid(t) == res
 
 
-def test_neighbors():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_neighbors(identifier):
     """test neighbors."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
 
     x, y, z = 243, 166, 9
     tiles = tms.neighbors(x, y, z)
@@ -552,9 +774,10 @@ def test_neighbors():
     assert all(t.y - y in (-1, 0, 1) for t in tiles)
 
 
-def test_neighbors_invalid():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_neighbors_invalid(identifier):
     """test neighbors."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
 
     x, y, z = 0, 166, 9
     tiles = tms.neighbors(x, y, z)
@@ -564,17 +787,19 @@ def test_neighbors_invalid():
     assert all(t.y - y in (-1, 0, 1) for t in tiles)
 
 
-def test_root_neighbors_invalid():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_root_neighbors_invalid(identifier):
     """test neighbors."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     x, y, z = 0, 0, 0
     tiles = tms.neighbors(x, y, z)
     assert len(tiles) == 0  # root tile has no neighbors
 
 
-def test_parent():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_parent(identifier):
     """test parent"""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     parent = tms.parent(486, 332, 10)
     assert parent[0] == morecantile.Tile(243, 166, 9)
 
@@ -584,16 +809,18 @@ def test_parent():
     assert tms.parent(0, 0, 0) == []
 
 
-def test_parent_multi():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_parent_multi(identifier):
     """test parent"""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     parent = tms.parent(486, 332, 10, zoom=8)
     assert parent[0] == morecantile.Tile(121, 83, 8)
 
 
-def test_children():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_children(identifier):
     """test children."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
 
     x, y, z = 243, 166, 9
     children = tms.children(x, y, z)
@@ -604,9 +831,10 @@ def test_children():
     assert morecantile.Tile(2 * x, 2 * y + 1, z + 1) in children
 
 
-def test_children_multi():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_children_multi(identifier):
     """test children multizoom."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
 
     children = tms.children(243, 166, 9, zoom=11)
     assert len(children) == 16
@@ -632,9 +860,10 @@ def test_children_multi():
         assert target in children
 
 
-def test_children_invalid_zoom():
+@pytest.mark.parametrize("identifier", ["WebMercatorQuad", "WebMercatorQuadBottomLeft"])
+def test_children_invalid_zoom(identifier):
     """invalid zoom."""
-    tms = morecantile.tms.get("WebMercatorQuad")
+    tms = morecantile.tms.get(identifier)
     with pytest.raises(InvalidZoomError):
         tms.children(243, 166, 9, zoom=8)
 


### PR DESCRIPTION
This PR adds support for bottomLeft cornerOfOrigin. 

cornerOfOrigin is specified in the OGC Two Dimensional Tile Matrix Set 2.0 specification and within the TileMatrix object model but is not currently handled anywhere in the morecantile code. This could be supported potentially "better" by through a refactor of the code that takes into account direction the matrix is heading instead of using if statements everywhere but instead I opted to add onto the API instead of introducing breaking changes. 

This is tested by adding a bunch of unit tests for various zoom levels and tiles but also by creating a new TileMatrixSet I called "WebMercatorQuadBottomLeft" which is just WebMercatorQuad but starts bottom left. WebMercatorQuadBottomLeft is loaded automatically using a session autouse=True fixture to load it into the tms registry. Testing this required adding arguments a bunch of tests to taken in the tile identifier as an pytest argument so as not to duplicate code too much.

I would not consider myself an expert on the OGC tile specification so any feedback or concerns would be appreciated. 

Functions added 

- `ur`, `_ur`, `ll`, and `_ll` 
  - These functions were added to help with getting the TMS and geographic coordinates of the tile since `ul` and `lr` since those are new origin points.
- `origin_coords` `_origin_coords`, `origin_coords_across`, and `_origin_coords_across`
  - These functions were added to help with getting the origin coordinates for a tile without the user having to guess the read the cornerOfOrigin themselves. This can be useful as a replacement for various usages of `ul` for any code that makes use of morecantile when figuring out where to start their tile placement from
- `translate_cornerOfOrigin_Tile` to `TileMatrix`
  - More of a utility function but adding this to utils.py with type hints will cause a circular import. This will translate a Tile object from one cornerOfOrigin to another. Mostly useful when testing

Functions api changed
- `TileMatrixSet.custom`
  - Added `point_of_origin` and `corner_of_origin` as optional kwargs which were previously being ignored

