### PR TITLE
check maxzoom in is_valid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,19 @@
 ## Unreleased
 
 * remove python 3.8 support
+* check `maxzoom` in `TileMatrixSet.is_valid`
+
+    ```python
+    import morecantile
+    tms = morecantile.tms.get("WebMercatorQuad")
+
+    # before
+    assert tms.is_valid(0, 0, 25)
+
+    # now
+    assert tms.is_valid(0, 0, 25), "Tile(0, 0, 25) is not valid"
+    >> AssertionError: Tile(0, 0, 25) is not valid
+    ```
 
 ## 6.2.0 (2024-12-19)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,10 +10,14 @@
 
     # before
     assert tms.is_valid(0, 0, 25)
+    >> UserWarning: TileMatrix not found for level: 25 - Creating values from TMS Scale.
 
     # now
     assert tms.is_valid(0, 0, 25), "Tile(0, 0, 25) is not valid"
     >> AssertionError: Tile(0, 0, 25) is not valid
+
+    assert tms.is_valid(0, 0, 25, strict=False)
+    >> UserWarning: TileMatrix not found for level: 25 - Creating values from TMS Scale.
     ```
 
 ## 6.2.0 (2024-12-19)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 ## Unreleased
 
 * remove python 3.8 support
-* check `maxzoom` in `TileMatrixSet.is_valid`
+* check tile's zoom against TMS's `maxzoom` in `TileMatrixSet.is_valid` and add `strict=True|False` options
 
     ```python
     import morecantile

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -1484,7 +1484,7 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         """Check if a tile is valid."""
         t = _parse_tile_arg(*tile)
 
-        if t.z < self.minzoom:
+        if t.z < self.minzoom or t.z > self.maxzoom:
             return False
 
         matrix = self.matrix(t.z)

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -1480,11 +1480,12 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
             "y": {"min": 0, "max": m.matrixHeight - 1},
         }
 
-    def is_valid(self, *tile: Tile) -> bool:
+    def is_valid(self, *tile: Tile, strict: bool = True) -> bool:
         """Check if a tile is valid."""
         t = _parse_tile_arg(*tile)
 
-        if t.z < self.minzoom or t.z > self.maxzoom:
+        disable_overzoom = self.is_variable or strict
+        if t.z < self.minzoom or (disable_overzoom and t.z > self.maxzoom):
             return False
 
         matrix = self.matrix(t.z)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ dependencies = [
     "attrs",
     "pyproj>=3.1,<4.0",
     "pydantic~=2.0",
-    # ref: https://github.com/pallets/click/issues/2939
-    "click!=8.2.1,!=8.2.2",
+    "click",
 ]
 
 [project.optional-dependencies]
@@ -37,6 +36,8 @@ test = [
     "pytest",
     "pytest-cov",
     "rasterio>=1.2.1",
+    # ref: https://github.com/pallets/click/issues/2939
+    "click!=8.2.1,!=8.2.2",
 ]
 benchmark = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "attrs",
     "pyproj>=3.1,<4.0",
     "pydantic~=2.0",
+    # ref: https://github.com/pallets/click/issues/2939
+    "click!=8.2.1,!=8.2.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -529,9 +529,18 @@ def test_is_power_of_two():
 @pytest.mark.parametrize(
     "t,res",
     [
+        #                 X  Y  Z
         (morecantile.Tile(0, 0, 0), True),
+        # zoom 0 has only tile 0,0,0 valid
         (morecantile.Tile(1, 0, 0), False),
+        # MinZoom is 0
         (morecantile.Tile(0, 0, -1), False),
+        # MaxZoom is 24
+        (morecantile.Tile(0, 0, 25), False),
+        # Negative X
+        (morecantile.Tile(-1, 0, 1), False),
+        # Negative Y
+        (morecantile.Tile(0, -1, 1), False),
     ],
 )
 def test_is_valid_tile(t, res):

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -536,6 +536,7 @@ def test_is_power_of_two():
         # MinZoom is 0
         (morecantile.Tile(0, 0, -1), False),
         # MaxZoom is 24
+        (morecantile.Tile(0, 0, 24), True),
         (morecantile.Tile(0, 0, 25), False),
         # Negative X
         (morecantile.Tile(-1, 0, 1), False),
@@ -547,6 +548,25 @@ def test_is_valid_tile(t, res):
     """test if tile are valid."""
     tms = morecantile.tms.get("WebMercatorQuad")
     assert tms.is_valid(t) == res
+
+
+def test_is_valid_overzoom():
+    """test if tile are valid."""
+    tms = morecantile.tms.get("WebMercatorQuad")
+    t = morecantile.Tile(0, 0, 25)
+    assert tms.is_valid(t, strict=False)
+    assert not tms.is_valid(t, strict=True)
+
+    tms = morecantile.tms.get("GNOSISGlobalGrid")
+    t = morecantile.Tile(0, 0, 28)
+    assert tms.is_valid(t, strict=False)
+
+    t = morecantile.Tile(0, 0, 29)
+    assert not tms.is_valid(t, strict=False)
+
+    # We can't overzoom VariableMatrixWidth TMS
+    t = morecantile.Tile(0, 0, 29)
+    assert not tms.is_valid(t)
 
 
 def test_neighbors():


### PR DESCRIPTION
closes https://github.com/developmentseed/morecantile/issues/176

I'm not yet 💯 convinced about this tbh 

if we would add a `strict=True/False` this will also conflict with variableMatrixWidths TMS because we could have `strict=False` but still raise False for is_valid when Z > maxzoom because we cannot construct Matrix for those. 

I think it's better just to raise `False` to respect the `TMS` definition. 