### PR TITLE
add geographic_crs option in tile and tiles methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,9 +28,8 @@
     }
     ```
 
-* rename `grid_name -> tms` and `grid_crs -> tms_crs` property names in `TileMatrixSet.feature` GeoJSON response
-* remove python 3.8 support
-* check tile's zoom against TMS's `maxzoom` in `TileMatrixSet.is_valid` and add `strict=True|False` options
+* rename `grid_name -> tms` and `grid_crs -> tms_crs` property names in `TileMatrixSet.feature` GeoJSON response **breaking change**
+* check tile's zoom against TMS's `maxzoom` in `TileMatrixSet.is_valid` and add `strict=True|False` options **breaking change**
 
     ```python
     import morecantile
@@ -47,6 +46,10 @@
     assert tms.is_valid(0, 0, 25, strict=False)
     >> UserWarning: TileMatrix not found for level: 25 - Creating values from TMS Scale.
     ```
+
+* remove `truncate_lnglat` from TileMatrixSet class **breaking change**
+* remove python 3.8 support
+* add `geographic_crs` option in `TileMatrixSet.tiles` and `TileMatrixSet.tile` methods
 
 ## 6.2.0 (2024-12-19)
 

--- a/morecantile/utils.py
+++ b/morecantile/utils.py
@@ -1,7 +1,7 @@
 """morecantile utils."""
 
 import math
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from pyproj import CRS
 from pyproj.enums import WktVersion
@@ -108,6 +108,28 @@ def point_in_bbox(point: Coords, bbox: BoundingBox, precision: int = 5) -> bool:
         and round(point.y, precision) >= round(bbox.bottom, precision)
         and round(point.y, precision) <= round(bbox.top, precision)
     )
+
+
+def truncate_coordinates(
+    lng: float, lat: float, bbox: BoundingBox
+) -> Tuple[float, float]:
+    """
+    Truncate coordinates to a given bbox.
+
+    Adapted from https://github.com/mapbox/mercantile/blob/master/mercantile/__init__.py
+
+    """
+    if lng > bbox.right:
+        lng = bbox.right
+    elif lng < bbox.left:
+        lng = bbox.left
+
+    if lat > bbox.top:
+        lat = bbox.top
+    elif lat < bbox.bottom:
+        lat = bbox.bottom
+
+    return lng, lat
 
 
 def is_power_of_two(number: int) -> bool:


### PR DESCRIPTION
same goal as https://github.com/developmentseed/morecantile/pull/167

This PR adds a `geographic_crs` option to both `TileMatrixSet.tile()` and `TileMatrixSet.tiles()` methods which allows user to use either the default Geographic CRS from the TMS's CRS definition or WGS84.

Note: a follow up PR will deprecate Geographic methods (`.bbox`, `.bounds()`, `.lr()`, `.ul()` and `.xy()`) because those methods add much more complexity and TMS shouldn't have to deal with how to transform from/to geographic CRS. 