### PR TITLE
deprecate geographic methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,12 @@
 
 ## Unreleased
 
+## 7.0.0 (TBD)
+
 * use `WGS84` as default CRS for `TileMatrixSet.feature` GeoJSON response (as per specification)
+
 * add `geographic_crs` option for `TileMatrixSet.feature` method
+
 * update non-WGS84 CRS notation in `TileMatrixSet.feature` GeoJSON response
 
     ```python
@@ -48,8 +52,14 @@
     ```
 
 * remove `truncate_lnglat` from TileMatrixSet class **breaking change**
-* remove python 3.8 support
+
 * add `geographic_crs` option in `TileMatrixSet.tiles` and `TileMatrixSet.tile` methods
+
+* add deprecation warning for `ul`, `lr`, `xy`, `lnglat` amd `bounds` TileMatrixSet's methods **Deprecation Notice**
+
+* add deprecation warning for `bbox` TileMatrixSet's property **Deprecation Notice**
+
+* remove python 3.8, 3.9 and 3.10 support
 
 ## 6.2.0 (2024-12-19)
 

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -906,6 +906,12 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
 
     def lnglat(self, x: float, y: float, truncate: bool = False) -> Coords:
         """Transform point(x,y) to geographic longitude and latitude."""
+        warnings.warn(
+            "`TileMatrixSet.lnglat` method is Deprecated and will be removed in morecantile 8.0",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
         inside = point_in_bbox(Coords(x, y), self.xy_bbox)
         if not inside:
             warnings.warn(
@@ -923,6 +929,12 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
 
     def xy(self, lng: float, lat: float, truncate: bool = False) -> Coords:
         """Transform geographic longitude and latitude coordinates to TMS CRS."""
+        warnings.warn(
+            "`TileMatrixSet.xy` method is Deprecated and will be removed in morecantile 8.0",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
         if truncate:
             lng, lat = truncate_coordinates(lng, lat, self.bbox)
 
@@ -1154,6 +1166,12 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         Coords: The upper left geographic coordinates of the input tile.
 
         """
+        warnings.warn(
+            "`TileMatrixSet.ul` method is Deprecated and will be removed in morecantile 8.0",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
         t = _parse_tile_arg(*tile)
 
         x, y = self._ul(t)
@@ -1172,6 +1190,12 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         Coords: The lower right geographic coordinates of the input tile.
 
         """
+        warnings.warn(
+            "`TileMatrixSet.lr` method is Deprecated and will be removed in morecantile 8.0",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
         t = _parse_tile_arg(*tile)
 
         x, y = self._lr(t)
@@ -1190,6 +1214,12 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         BoundingBox: The bounding box of the input tile.
 
         """
+        warnings.warn(
+            "`TileMatrixSet.bounds` method is Deprecated and will be removed in morecantile 8.0",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
         _left, _bottom, _right, _top = self.xy_bounds(*tile)
         left, top = self.lnglat(_left, _top)
         right, bottom = self.lnglat(_right, _bottom)
@@ -1208,9 +1238,15 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
         )
         return BoundingBox(left, bottom, right, top)
 
-    @cached_property
+    @property
     def bbox(self):
         """Return TMS bounding box in geographic coordinate reference system."""
+        warnings.warn(
+            "`TileMatrixSet.bbox` property is Deprecated and will be removed in morecantile 8.0",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
         left, bottom, right, top = self.xy_bbox
         return BoundingBox(
             *self._to_geographic.transform_bounds(

--- a/morecantile/models.py
+++ b/morecantile/models.py
@@ -492,8 +492,8 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
     ]
 
     # Private attributes
-    _to_geographic: pyproj.Transformer = PrivateAttr()
-    _from_geographic: pyproj.Transformer = PrivateAttr()
+    _to_geographic: pyproj.Transformer = PrivateAttr()  # NOTE: Will be removed in 8.0
+    _from_geographic: pyproj.Transformer = PrivateAttr()  # NOTE: Will be removed in 8.0
 
     _tile_matrices_idx: Dict[int, int] = PrivateAttr()
 
@@ -505,6 +505,7 @@ class TileMatrixSet(BaseModel, arbitrary_types_allowed=True):
             int(mat.id): idx for idx, mat in enumerate(self.tileMatrices)
         }
 
+        # NOTE: Will be removed in 8.0
         try:
             self._to_geographic = pyproj.Transformer.from_crs(
                 self.crs._pyproj_crs, self.crs._pyproj_crs.geodetic_crs, always_xy=True


### PR DESCRIPTION
ref https://github.com/developmentseed/morecantile/issues/179

Those deprecation will make morecantile more robust and focus on the TMS specification representation it self instead of having to deal with Geographic transformation 

some could create a Compat class like 

```python

from dataclasses import dataclass, field
import warnings
from functools import cached_property
from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple, Union

import pyproj
from pyproj.exceptions import ProjError

from .models import TileMatrixSet
from .commons import BoundingBox, Coords, Tile
from .errors import PointOutsideTMSBounds
from .utils import _parse_tile_arg, point_in_bbox, truncate_coordinates

WGS84_CRS = pyproj.CRS.from_epsg(4326)


@dataclass
class GeoTileMatrixSet:
    
    tms: TileMatrixSet
    geographic_crs: pyproj.CRS | None = None

    _to_geographic: pyproj.Transformer = field(init=False)
    _from_geographic: pyproj.Transformer = field(init=False)

    def __post_init__(self):

        geographic_crs = self.geographic_crs or self.tms.crs._pyproj_crs.geodetic_crs or WGS84_CRS
        try:
            self._to_geographic = pyproj.Transformer.from_crs(
                self.tms.crs._pyproj_crs, geographic_crs, always_xy=True
            )
            self._from_geographic = pyproj.Transformer.from_crs(
                geographic_crs, self.tms.crs._pyproj_crs, always_xy=True
            )
        except ProjError:
            warnings.warn(
                "Could not create coordinate Transformer from input CRS to the given geographic CRS"
                "some methods might not be available.",
                UserWarning,
                stacklevel=1,
            )
            self._to_geographic = None
            self._from_geographic = None


    def lnglat(self, x: float, y: float, truncate: bool = False) -> Coords:
        """Transform point(x,y) to geographic longitude and latitude."""
        inside = point_in_bbox(Coords(x, y), self.tms.xy_bbox)
        if not inside:
            warnings.warn(
                f"Point ({x}, {y}) is outside TMS bounds {list(self.tms.xy_bbox)}.",
                PointOutsideTMSBounds,
                stacklevel=1,
            )

        lng, lat = self._to_geographic.transform(x, y)
        if truncate:
            lng, lat = truncate_coordinates(lng, lat, self.bbox)

        return Coords(lng, lat)

    def xy(self, lng: float, lat: float, truncate: bool = False) -> Coords:
        """Transform geographic longitude and latitude coordinates to TMS CRS."""
        if truncate:
            lng, lat = truncate_coordinates(lng, lat, self.bbox)

        inside = point_in_bbox(Coords(lng, lat), self.bbox)
        if not inside:
            warnings.warn(
                f"Point ({lng}, {lat}) is outside TMS bounds {list(self.bbox)}.",
                PointOutsideTMSBounds,
                stacklevel=1,
            )

        x, y = self._from_geographic.transform(lng, lat)
        return Coords(x, y)
    
    def ul(self, *tile: Tile) -> Coords:
        """
        Return the upper left coordinates of the tile in geographic coordinate reference system.

        Attributes
        ----------
        tile (tuple or Tile): (x, y, z) tile coordinates or a Tile object we want the upper left geographic coordinates of.

        Returns
        -------
        Coords: The upper left geographic coordinates of the input tile.

        """
        x, y = self.tms._ul(*tile)
        return Coords(*self.lnglat(x, y))

    def lr(self, *tile: Tile) -> Coords:
        """
        Return the lower right coordinates of the tile in geographic coordinate reference system.

        Attributes
        ----------
        tile (tuple or Tile): (x, y, z) tile coordinates or a Tile object we want the lower right geographic coordinates of.

        Returns
        -------
        Coords: The lower right geographic coordinates of the input tile.

        """
        x, y = self.tms._lr(*tile)
        return Coords(*self.lnglat(x, y))

    def bounds(self, *tile: Tile) -> BoundingBox:
        """
        Return the bounding box of the tile in geographic coordinate reference system.

        Attributes
        ----------
        tile (tuple or Tile): A tuple of (x, y, z) tile coordinates or a Tile object we want the bounding box of.

        Returns
        -------
        BoundingBox: The bounding box of the input tile.

        """
        _left, _bottom, _right, _top = self.tms.xy_bounds(*tile)
        left, top = self.lnglat(_left, _top)
        right, bottom = self.lnglat(_right, _bottom)

        return BoundingBox(left, bottom, right, top)

    @cached_property
    def bbox(self):
        """Return TMS bounding box in geographic coordinate reference system."""
        left, bottom, right, top = self.tms.xy_bbox
        return BoundingBox(
            *self._to_geographic.transform_bounds(
                left,
                bottom,
                right,
                top,
                densify_pts=21,
            )
        )
```

```python
import morecantile
geo_tms = GeoTileMatrixSet(morecantile.tms.get("WebMercatorQuad"))

geo_tms.bbox
>> BoundingBox(left=-180.0, bottom=-85.0511287798066, right=180.00000000000009, top=85.0511287798066)

geo_tms.ul(0,0,0)
>> Coords(x=-180.0, y=85.0511287798066)
```