### PR TITLE
refactor geographic crs attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,8 +48,13 @@
     ```
 
 * remove `truncate_lnglat` from TileMatrixSet class **breaking change**
-* remove python 3.8 support
+* remove python 3.8, 3.9 and 3.10 support
 * add `geographic_crs` option in `TileMatrixSet.tiles` and `TileMatrixSet.tile` methods
+* make every `TileMatrixSet`'s attribute **frozen** 
+* rename `morecantile.defaults.TileMatrixSets.tms` attribute to `tilematrixsets` **breaking change**
+* make sure that `morecantile.defaults.TileMatrixSets.get(name)` returns a copy of the TMS object
+* add `MORECANTILE_DEFAULT_GEOGRAPHIC_CRS` environment variable to control the default Geographic CRS
+* add `TileMatrixSet.set_geographic_crs(crs: pyproj.CRS)` method to overwrite the geographic CRS
 
 ## 6.2.0 (2024-12-19)
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,6 +23,8 @@ extra:
 nav:
   - Home: 'index.md'
   - Usage: 'usage.md'
+  - Advanced:
+    - Geographic Transformations: advanced/geographic.md
   - TMS v2: 'tms-v2.md'
   - API:
     - morecantile.commons: api/morecantile/commons.md

--- a/docs/src/advanced/geographic.md
+++ b/docs/src/advanced/geographic.md
@@ -1,0 +1,80 @@
+
+Several methods/properties of the **morecantile.TileMatrixSet** object use Geographic Coordinates Reference System (CRS) to transform coordinates from/to the TMS's CRS:
+
+- `TileMatrixSet.lnglat(x, y)`: Transform point(x,y) to geographic longitude and latitude
+- `TileMatrixSet.xy(lng, lat)`: Transform geographic longitude and latitude coordinates to TMS CRS
+- `TileMatrixSet.ul(Tile)`: Return the upper left coordinates of the tile in geographic coordinate reference system
+- `TileMatrixSet.lr(Tile)`: Return the lower right coordinates of the tile in geographic coordinate reference system
+- `TileMatrixSet.bounds(Tile)`: Return the bounding box of the tile in geographic coordinate reference system
+- `TileMatrixSet.bbox`: Return TMS bounding box in geographic coordinate reference system
+
+For those methods/properties, the Geographic CRS is defined by the TileMatrixSet CRS's geographic CRS (`CRS.geodetic_crs`). The most common one is the `World Geodetic System 1984` (`WGS84` or `EPSG:4326`) but it's not the one used by default.
+
+```python
+import morecantile 
+
+morecantile.tms.get("WebMercatorQuad").geographic_crs
+>> <Geographic 2D CRS: EPSG:4326>
+Name: WGS 84
+Axis Info [ellipsoidal]:
+- Lat[north]: Geodetic latitude (degree)
+- Lon[east]: Geodetic longitude (degree)
+Area of Use:
+- name: World.
+- bounds: (-180.0, -90.0, 180.0, 90.0)
+Datum: World Geodetic System 1984 ensemble
+- Ellipsoid: WGS 84
+- Prime Meridian: Greenwich
+
+morecantile.tms.get("CanadianNAD83_LCC").geographic_crs
+>> <Geographic 2D CRS: EPSG:4269>
+Name: NAD83
+Axis Info [ellipsoidal]:
+- Lat[north]: Geodetic latitude (degree)
+- Lon[east]: Geodetic longitude (degree)
+Area of Use:
+- name: North America - onshore and offshore: Canada - Alberta; British Columbia; Manitoba; New Brunswick; Newfoundland and Labrador; Northwest Territories; Nova Scotia; Nunavut; Ontario; Prince Edward Island; Quebec; Saskatchewan; Yukon. Puerto Rico. United States (USA) - Alabama; Alaska; Arizona; Arkansas; California; Colorado; Connecticut; Delaware; Florida; Georgia; Hawaii; Idaho; Illinois; Indiana; Iowa; Kansas; Kentucky; Louisiana; Maine; Maryland; Massachusetts; Michigan; Minnesota; Mississippi; Missouri; Montana; Nebraska; Nevada; New Hampshire; New Jersey; New Mexico; New York; North Carolina; North Dakota; Ohio; Oklahoma; Oregon; Pennsylvania; Rhode Island; South Carolina; South Dakota; Tennessee; Texas; Utah; Vermont; Virginia; Washington; West Virginia; Wisconsin; Wyoming. US Virgin Islands. British Virgin Islands.
+- bounds: (167.65, 14.92, -40.73, 86.45)
+Datum: North American Datum 1983
+- Ellipsoid: GRS 1980
+- Prime Meridian: Greenwich
+```
+
+### Overwriting the Geographic CRS
+
+There are **two** mechanisms to overwrite the TMS's geographic CRS.
+
+- `TileMatrixSet.set_geographic_crs(crs)`: Overwrite the TMS's Geographic CRS (`TileMatrixSet._geographic_crs` private attribute)
+
+```python
+import morecantile
+import pyproj
+
+tms = morecantile.tms.get("CanadianNAD83_LCC")
+tms.geographic_crs
+>> <Geographic 2D CRS: EPSG:4269>
+...
+
+tms.set_geographic_crs(pyproj.CRS.from_epsg(4326))
+tms.geographic_crs
+>> <Geographic 2D CRS: EPSG:4326>
+...
+```
+
+- `MORECANTILE_DEFAULT_GEOGRAPHIC_CRS` environment variable
+
+```python
+import os
+os.environ["MORECANTILE_DEFAULT_GEOGRAPHIC_CRS"] = "EPSG:4326"
+
+import morecantile
+
+tms = morecantile.tms.get("CanadianNAD83_LCC")
+tms.geographic_crs
+>> <Geographic 2D CRS: EPSG:4326>
+```
+
+Some methods have `geographic_crs` option to specify the CRS to use to transf the default CRS:
+
+- `TileMatrixSet.tile(lng, lat, *, geographic_crs=None)`: Get the tile for a given geographic longitude and latitude pair
+- `TileMatrixSet.tiles(west, south, east, north, *, geographic_crs=None)`: Get the tiles overlapped by a geographic bounding box

--- a/morecantile/data/NZTM2000Quad.json
+++ b/morecantile/data/NZTM2000Quad.json
@@ -1,6 +1,5 @@
 {
     "title": "LINZ NZTM2000Quad Map Tile Grid",
-    "abstract": "See https://github.com/linz/NZTM2000TileMatrixSet",
     "id": "NZTM2000Quad",
     "crs": "urn:ogc:def:crs:EPSG::2193",
     "orderedAxes": [

--- a/morecantile/defaults.py
+++ b/morecantile/defaults.py
@@ -2,7 +2,7 @@
 
 import os
 import pathlib
-from copy import copy
+from copy import copy, deepcopy
 from typing import Dict, List, Union
 
 import attr
@@ -26,26 +26,26 @@ default_tms: Dict[str, Union[TileMatrixSet, pathlib.Path]] = {
 class TileMatrixSets:
     """Default TileMatrixSets holder."""
 
-    tms: Dict = attr.ib()
+    tilematrixsets: Dict = attr.ib()
 
     def get(self, identifier: str) -> TileMatrixSet:
         """Fetch a TMS."""
-        if identifier not in self.tms:
+        if identifier not in self.tilematrixsets:
             raise InvalidIdentifier(f"Invalid identifier: {identifier}")
 
-        tms = self.tms[identifier]
+        tilematrix = self.tilematrixsets[identifier]
 
         # We lazyload the TMS document only when called
-        if isinstance(tms, pathlib.Path):
-            with tms.open() as f:
-                tms = TileMatrixSet.model_validate_json(f.read())
-                self.tms[identifier] = tms
+        if isinstance(tilematrix, pathlib.Path):
+            with tilematrix.open() as f:
+                tilematrix = TileMatrixSet.model_validate_json(f.read())
+                self.tilematrixsets[identifier] = tilematrix
 
-        return tms
+        return deepcopy(tilematrix)
 
     def list(self) -> List[str]:
         """List registered TMS."""
-        return list(self.tms.keys())
+        return list(self.tilematrixsets.keys())
 
     def register(
         self,
@@ -54,10 +54,10 @@ class TileMatrixSets:
     ) -> "TileMatrixSets":
         """Register TileMatrixSet(s)."""
         for identifier in custom_tms.keys():
-            if identifier in self.tms and not overwrite:
+            if identifier in self.tilematrixsets and not overwrite:
                 raise InvalidIdentifier(f"{identifier} is already a registered TMS.")
 
-        return TileMatrixSets({**self.tms, **custom_tms})
+        return TileMatrixSets({**self.tilematrixsets, **custom_tms})
 
 
 tms = TileMatrixSets(copy(default_tms))  # noqa

--- a/tests/test_morecantile.py
+++ b/tests/test_morecantile.py
@@ -59,7 +59,7 @@ def test_register():
     assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT
 
     # Update internal TMS dict
-    morecantile.tms.tms["MyCustomGrid3031"] = tms
+    morecantile.tms.tilematrixsets["MyCustomGrid3031"] = tms
     assert len(morecantile.tms.list()) == DEFAULT_GRID_COUNT + 1
 
     # make sure it doesn't propagate to the default dict


### PR DESCRIPTION
This PR does:

- add `MORECANTILE_DEFAULT_GEOGRAPHIC_CRS` environment variable to control the default Geographic CRS
- add `TileMatrixSet.set_geographic_crs(crs: pyproj.CRS)` method to overwrite the geographic CRS

Instead of removing the Geographic methods as proposed in #182, this PR adds way to set default geographic CRS for the whole environment or for each TMS object (`set_geographic_crs` method). 
