### PR TITLE
docs: add example for finding tiles for a bounding box

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 
 ## Unreleased
 
+* docs: add example of how to enumerate tiles for a bounding box and zoom level(s)
 * use `WGS84` as default CRS for `TileMatrixSet.feature` GeoJSON response (as per specification)
 * add `geographic_crs` option for `TileMatrixSet.feature` method
 * update non-WGS84 CRS notation in `TileMatrixSet.feature` GeoJSON response

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -41,6 +41,30 @@ tms._tile(x, y, 4)
 >>> Tile(x=15, y=10, z=4)
 ```
 
+### Find all tiles for a bounding box and zoom level(s)
+
+```python
+import morecantile
+
+tms = morecantile.tms.get("WebMercatorQuad")
+
+tiles = tms.tiles(
+    west=-93,
+    south=46,
+    east=-92,
+    north=47,
+    zooms=[8],
+)
+
+for tile in tiles:
+    print(tile)
+
+>>> Tile(x=61, y=90, z=8)
+>>> Tile(x=62, y=90, z=8)
+>>> Tile(x=61, y=91, z=8)
+>>> Tile(x=62, y=91, z=8)
+```
+
 ### Get Geojson Feature
 
 ```python


### PR DESCRIPTION
Just a nice feature from `morecantile` that deserves an example in the docs!